### PR TITLE
fix(transducers): Provide argument types for compR() and deepTransform()

### DIFF
--- a/packages/transducers/src/func/compr.ts
+++ b/packages/transducers/src/func/compr.ts
@@ -1,5 +1,5 @@
 import { Reducer } from "../api";
 
-export function compR(rfn: Reducer<any, any>, fn: (acc, x) => any) {
+export function compR(rfn: Reducer<any, any>, fn: (acc: any, x: any) => any) {
     return <Reducer<any, any>>[rfn[0], rfn[1], fn];
 }

--- a/packages/transducers/src/func/deep-transform.ts
+++ b/packages/transducers/src/func/deep-transform.ts
@@ -63,7 +63,7 @@ import { TransformSpec } from "../api";
  *
  * @param spec transformation spec
  */
-export function deepTransform(spec: TransformSpec): (x) => any {
+export function deepTransform(spec: TransformSpec): (x: any) => any {
     if (isFunction(spec)) {
         return <any>spec;
     }


### PR DESCRIPTION
Fixes compile errors in strict mode.