### PR TITLE
fix(rstream): unsubscribe on error in transduce()

### DIFF
--- a/packages/rstream/src/subs/transduce.ts
+++ b/packages/rstream/src/subs/transduce.ts
@@ -21,6 +21,7 @@ export function transduce<A, B, C>(src: Subscription<any, A>, tx: Transducer<A, 
                 resolve(acc);
             },
             error(e) {
+                sub.unsubscribe();
                 reject(e);
             }
         }, tx);


### PR DESCRIPTION
`transduce()` should also unsubscribe from input stream in case of an error. Otherwise we leak the inner subscription.