### PR TITLE
fix(rstream): Fix unbound this in method call expression

### DIFF
--- a/packages/rstream/src/subs/resolve.ts
+++ b/packages/rstream/src/subs/resolve.ts
@@ -57,7 +57,14 @@ export class Resolver<T> extends Subscription<Promise<T>, T> {
                     DEBUG && console.log(`resolved value in ${State[this.state]} state (${x})`);
                 }
             },
-            (e) => (this.fail || this.error)(e)
+            (e) => {
+                if (this.fail) {
+                    this.fail(e);
+                }
+                else {
+                    this.error(e);
+                }
+            }
         );
     }
 


### PR DESCRIPTION
This PR fixes the reject handler of the `Resolver.next()` method.

Previously, the expression 
```js
(this.fail || this.error)(e)
``` 
would call the error method of the prototype if no `this.fail` was defined, but without binding `this` to the current object. Thus, the first statement of `Subscription.error()` would fail with the following error:

`TypeError: Cannot set property 'state' of undefined`