### PR TITLE
fix(vectors): fix NaNs in Mat23.scaleWithCenter

### DIFF
--- a/packages/vectors/src/mat23.ts
+++ b/packages/vectors/src/mat23.ts
@@ -192,7 +192,7 @@ export class Mat23 implements
     }
 
     static scaleWithCenter(p: Readonly<Vec2>, sx: number, sy = sx) {
-        return new Mat23(scaleWithCenter23([], p.buf, sx, sy, p.i, p.s));
+        return new Mat23(scaleWithCenter23([], p.buf, sx, sy, 0, p.i, p.s));
     }
 
     static translation(v: Readonly<Vec2>): Mat23;


### PR DESCRIPTION
lack of 0 mat index caused incorrect indexing into point. Fixes #65 