### PR TITLE
fix(cache): TLRU: expected behavior on getSet()

### DIFF
--- a/packages/cache/src/tlru.ts
+++ b/packages/cache/src/tlru.ts
@@ -78,6 +78,14 @@ export class TLRUCache<K, V> extends LRUCache<K, V> {
         return value;
     }
 
+    getSet(key: K, retrieve: () => Promise<V>, ttl = this.opts.ttl): Promise<V> {
+        const e = this.get(key);
+        if (e) {
+            return Promise.resolve(e);
+        }
+        return retrieve().then((v) => this.set(key, v, ttl));
+    }
+
     prune() {
         const now = Date.now();
         let cell = this.items.head;

--- a/packages/cache/test/tlru.ts
+++ b/packages/cache/test/tlru.ts
@@ -50,4 +50,18 @@ describe("TLRU", () => {
         }, 20);
     });
 
+    it("getSet ttl", (done) => {
+        setTimeout(() => {
+            c.getSet("a", () => Promise.resolve(10)).then(v => {
+                assert.equal(v, 10);
+                assert(!c.has("b"));
+                assert(!c.has("c"));
+                assert.deepEqual([...evicts], [["a", 1], ["b", 2], ["c", 3]]);
+                assert.deepEqual([...c.keys()], ["a"]);
+                assert.deepEqual([...c.values()], [10]);
+                done();
+            }).catch(done)
+        }, 20)
+    });
+
 });


### PR DESCRIPTION
`TLRU.getSet()` behaves like just LRU cache. This method was inhereted from LRU and was not aware of TTL.