### PR TITLE
[fix] [compose] Preserve Promise type in `delayed`

### DIFF
--- a/packages/compose/src/delayed.ts
+++ b/packages/compose/src/delayed.ts
@@ -1,2 +1,2 @@
 export const delayed = <T>(x: T, t: number) =>
-    new Promise((resolve) => setTimeout(() => resolve(x), t));
+    new Promise<T>((resolve) => setTimeout(() => resolve(x), t));


### PR DESCRIPTION
Without this annotation, the generic parameter has no effect on the return type.

I have not run this locally to see whether there's any effect on tests.  Honestly, I just wanted to see whether or not I could really make this edit in place :)

I will build locally and update.  Thanks.