### PR TITLE
fix(webgl): update check for WEBGL_draw_buffers

### DIFF
--- a/packages/webgl/src/fbo.ts
+++ b/packages/webgl/src/fbo.ts
@@ -34,7 +34,7 @@ export class FBO implements IFbo {
     constructor(gl: WebGLRenderingContext, opts?: Partial<FboOpts>) {
         this.gl = gl;
         this.fbo = gl.createFramebuffer() || error("error creating FBO");
-        this.ext = !isGL2Context(gl)
+        this.ext = (!isGL2Context(gl) && opts && opts!.tex && opts!.tex!.length > 1)
             ? gl.getExtension("WEBGL_draw_buffers") ||
               error("missing WEBGL_draw_buffers ext")
             : undefined;


### PR DESCRIPTION
Added check for the number of FBO render targets before actually getting the extension.

For most mobile browsers, [WEBGL_draw_buffers](https://webglstats.com/webgl/extension/WEBGL_draw_buffers) is not supported, but FBOs with single render target are still usable. 