### PR TITLE
Add atan signature with two input

### DIFF
--- a/packages/shader-ast/src/builtins.ts
+++ b/packages/shader-ast/src/builtins.ts
@@ -117,7 +117,17 @@ export const sin = primOp1("sin");
 export const tan = primOp1("tan");
 export const acos = primOp1("acos");
 export const asin = primOp1("asin");
-export const atan = primOp1("atan");
+
+export function atan<T extends Prim>(a: Term<T>): FnCall<T>;
+export function atan<A extends Prim, B extends A>(
+    a: Term<A>,
+    b: Term<B>
+): FnCall<A>;
+export function atan(a:any, b?: any) {
+    return b
+        ? builtinCall("atan", a.type, a, b)
+        : builtinCall("atan", a.type, a);
+}
 
 export const pow = primOp2("pow");
 export const exp = primOp1("exp");

--- a/packages/shader-ast/src/builtins.ts
+++ b/packages/shader-ast/src/builtins.ts
@@ -123,7 +123,7 @@ export function atan<A extends Prim, B extends A>(
     a: Term<A>,
     b: Term<B>
 ): FnCall<A>;
-export function atan(a:any, b?: any) {
+export function atan(a:Term<any>, b?: Term<any>) {
     return b
         ? builtinCall("atan", a.type, a, b)
         : builtinCall("atan", a.type, a);


### PR DESCRIPTION
To be a little bit more compliant with GLSL spec `atan` function has two signatures.
See here: https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/atan.xhtml