### PR TITLE
refactor(checks) Stronger typing for `exists`

### DIFF
--- a/packages/checks/src/exists.ts
+++ b/packages/checks/src/exists.ts
@@ -1,1 +1,1 @@
-export const exists = (x: any) => x !== undefined;
+export const exists = <T>(t: T | undefined): t is T => t !== undefined;


### PR DESCRIPTION
This causes `exists` to function as a type guard, preserving the original type of the input.

I have been using this version locally, and I don't think it breaks any builds.  (There is no change to runtime behavior).