### PR TITLE
refactor(api): Use `this` parameter to avoid casts in mixins.

### DIFF
--- a/packages/api/src/mixins/ienable.ts
+++ b/packages/api/src/mixins/ienable.ts
@@ -20,28 +20,26 @@ interface _IEnable extends IEnable<any> {
 export const IEnableMixin = mixin(<IEnable<any>>{
     _enabled: true,
 
-    isEnabled() {
-        return (<_IEnable>this)._enabled;
+    isEnabled(this: _IEnable) {
+        return this._enabled;
     },
 
-    enable() {
-        const $this = <_IEnable>this;
-        $this._enabled = true;
-        if ($this.notify) {
-            $this.notify({ id: EVENT_ENABLE, target: this });
+    enable(this: _IEnable) {
+        this._enabled = true;
+        if (this.notify) {
+            this.notify({ id: EVENT_ENABLE, target: this });
         }
     },
 
-    disable() {
-        const $this = <_IEnable>this;
-        $this._enabled = false;
-        if ($this.notify) {
-            $this.notify({ id: EVENT_DISABLE, target: this });
+    disable(this: _IEnable) {
+        this._enabled = false;
+        if (this.notify) {
+            this.notify({ id: EVENT_DISABLE, target: this });
         }
     },
 
-    toggle() {
-        (<_IEnable>this)._enabled ? this.disable() : this.enable();
-        return (<_IEnable>this)._enabled;
+    toggle(this: _IEnable) {
+        this._enabled ? this.disable() : this.enable();
+        return this._enabled;
     }
 });

--- a/packages/api/src/mixins/inotify.ts
+++ b/packages/api/src/mixins/inotify.ts
@@ -29,24 +29,24 @@ export const inotify_dispatch = (listeners: any[][], e: Event) => {
  * registered listeners.
  */
 export const INotifyMixin = mixin(<INotify>{
-    addListener(id: string, fn: Listener, scope?: any) {
-        let l = ((<_INotify>this)._listeners =
-            (<_INotify>this)._listeners || {})[id];
+    addListener(this: _INotify, id: string, fn: Listener, scope?: any) {
+        let l = (this._listeners =
+            this._listeners || {})[id];
         if (!l) {
-            l = (<any>this)._listeners[id] = [];
+            l = this._listeners[id] = [];
         }
-        if ((<_INotify>this).__listener(l, fn, scope) === -1) {
+        if (this.__listener(l, fn, scope) === -1) {
             l.push([fn, scope]);
             return true;
         }
         return false;
     },
 
-    removeListener(id: string, fn: Listener, scope?: any) {
-        if (!(<_INotify>this)._listeners) return false;
-        const l = (<_INotify>this)._listeners[id];
+    removeListener(this: _INotify, id: string, fn: Listener, scope?: any) {
+        if (!this._listeners) return false;
+        const l = this._listeners[id];
         if (l) {
-            const idx = (<_INotify>this).__listener(l, fn, scope);
+            const idx = this.__listener(l, fn, scope);
             if (idx !== -1) {
                 l.splice(idx, 1);
                 return true;
@@ -55,11 +55,11 @@ export const INotifyMixin = mixin(<INotify>{
         return false;
     },
 
-    notify(e: Event) {
-        if (!(<_INotify>this)._listeners) return;
+    notify(this: _INotify, e: Event) {
+        if (!this._listeners) return;
         e.target === undefined && (e.target = this);
-        inotify_dispatch((<_INotify>this)._listeners[<string>e.id], e);
-        inotify_dispatch((<_INotify>this)._listeners[EVENT_ALL], e);
+        inotify_dispatch(this._listeners[<string>e.id], e);
+        inotify_dispatch(this._listeners[EVENT_ALL], e);
     },
 
     __listener(listeners: [Listener, any][], f: Listener, scope: any) {

--- a/packages/api/src/mixins/iwatch.ts
+++ b/packages/api/src/mixins/iwatch.ts
@@ -11,27 +11,27 @@ interface _IWatch extends IWatch<any> {
 }
 
 export const IWatchMixin = mixin(<IWatch<any>>{
-    addWatch(id: string, fn: Fn3<string, any, any, void>) {
-        (<_IWatch>this)._watches = (<_IWatch>this)._watches || {};
-        if ((<_IWatch>this)._watches[id]) {
+    addWatch(this: _IWatch, id: string, fn: Fn3<string, any, any, void>) {
+        this._watches = this._watches || {};
+        if (this._watches[id]) {
             return false;
         }
-        (<_IWatch>this)._watches[id] = fn;
+        this._watches[id] = fn;
         return true;
     },
 
-    removeWatch(id: string) {
-        if (!(<_IWatch>this)._watches) return;
-        if ((<_IWatch>this)._watches[id]) {
-            delete (<_IWatch>this)._watches[id];
+    removeWatch(this: _IWatch, id: string) {
+        if (!this._watches) return;
+        if (this._watches[id]) {
+            delete this._watches[id];
             return true;
         }
         return false;
     },
 
-    notifyWatches(oldState: any, newState: any) {
-        if (!(<_IWatch>this)._watches) return;
-        const w = (<_IWatch>this)._watches;
+    notifyWatches(this: _IWatch, oldState: any, newState: any) {
+        if (!this._watches) return;
+        const w = this._watches;
         for (let id in w) {
             w[id](id, oldState, newState);
         }


### PR DESCRIPTION
This simplifies the mixins code by using [`this` parameters](https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters).  It has no effect on runtime, though it does eliminate intermediate variables that were being used to reduce the number of casts.