### PR TITLE
refactor(malloc): save state inside the ArrayBuffer

### DIFF
--- a/packages/malloc/src/api.ts
+++ b/packages/malloc/src/api.ts
@@ -9,11 +9,16 @@ export interface MemBlock {
 export interface MemPoolOpts {
     buf: ArrayBuffer;
     size: number;
+    /**
+     * Start is the anchor index inside the arraybuffer, so we can't save it inside the arraybuffer itself.
+     * If you pass the ArrayBuffer to other consumers they must use the same start value
+     */
     start: number;
     end: number;
     compact: boolean;
     split: boolean;
     minSplit: number;
+    skipInitialization: boolean
 }
 
 export interface MemPoolStats {

--- a/packages/malloc/test/index.ts
+++ b/packages/malloc/test/index.ts
@@ -1,6 +1,9 @@
 import { Type } from "@thi.ng/api";
 import * as assert from "assert";
-import { MemPool } from "../src/index";
+import { MemPool, MemBlock } from "../src/index";
+
+const POOL_OVERHEAD = 16;
+const BLOCK_OVERHEAD = 8;
 
 describe("malloc", () => {
     let pool: MemPool;
@@ -13,13 +16,17 @@ describe("malloc", () => {
         assert(pool instanceof MemPool);
         let p: any = pool;
         assert.equal(p.start, 0x08);
-        assert.equal(p.top, 0x08);
+        assert.equal(p.top, 0x08 + POOL_OVERHEAD);
         assert(p.doCompact);
         assert(p.doSplit);
-        assert.equal(p.end, p.buf.byteLength);
+        assert.equal(
+            p.end,
+            p.buf.byteLength,
+            "When end option not specified, end should be byteLength"
+        );
         p = new MemPool({ size: 0x100, start: 0x0c, end: 0x80 });
         assert.equal(p.start, 0x10);
-        assert.equal(p.top, 0x10);
+        assert.equal(p.top, 0x10 + POOL_OVERHEAD);
         assert.equal(p.end, 0x80);
         assert.throws(() => new MemPool({ size: 0x100, start: 0x0, end: 0x0 }));
         assert.throws(
@@ -38,15 +45,18 @@ describe("malloc", () => {
         let a = pool.malloc(12);
         let b = pool.malloc(31);
         let c = pool.malloc(24);
-        assert.equal(a, 8, "a");
-        assert.equal(b, a + 16, "b");
-        assert.equal(c, b + 32, "c");
+        assert.equal(a, 8 + (POOL_OVERHEAD + BLOCK_OVERHEAD), "a");
+        assert.equal(b, a + 16 + BLOCK_OVERHEAD, "b");
+        assert.equal(c, b + 32 + BLOCK_OVERHEAD, "c");
 
         // state check
         let stats = pool.stats();
         assert.equal(stats.top, c + 24, "top");
         assert.deepEqual(stats.free, { count: 0, size: 0 });
-        assert.deepEqual(stats.used, { count: 3, size: 16 + 32 + 24 });
+        assert.deepEqual(stats.used, {
+            count: 3,
+            size: 16 + 32 + 24 + (POOL_OVERHEAD + BLOCK_OVERHEAD)
+        });
 
         // free all
         assert(pool.free(a), "free a");
@@ -54,77 +64,107 @@ describe("malloc", () => {
         assert(pool.free(b), "free c");
         assert(!pool.free(b), "free b (repeat)");
         stats = pool.stats();
-        assert.equal(stats.top, 8, "top2");
+        assert.equal(stats.top, 8 + POOL_OVERHEAD, "top2");
         assert.deepEqual(stats.free, { count: 0, size: 0 });
         assert.deepEqual(stats.used, { count: 0, size: 0 });
 
         // alloc & split free block
         a = pool.malloc(32);
-        assert.equal(a, 8, "a2");
+        assert.equal(a, 8 + POOL_OVERHEAD + BLOCK_OVERHEAD, "a2");
         stats = pool.stats();
         assert.deepEqual(stats.free, { count: 0, size: 0 });
-        assert.deepEqual(stats.used, { count: 1, size: 32 });
-        assert.equal(stats.top, 40, "top3");
+        assert.deepEqual(stats.used, { count: 1, size: 32 + BLOCK_OVERHEAD });
+        assert.equal(
+            stats.top,
+            40 + POOL_OVERHEAD + BLOCK_OVERHEAD * 1,
+            "top3"
+        );
         // alloc next block & free prev
         b = pool.malloc(12);
-        assert.equal(b, 40, "b2");
+        assert.equal(b, 40 + POOL_OVERHEAD + BLOCK_OVERHEAD * 2, "b2");
         assert(pool.free(a), "free a2");
 
         // re-alloc from free & split
         a = pool.malloc(8);
-        assert.equal(a, 8, "a3");
+        assert.equal(a, 8 + POOL_OVERHEAD + BLOCK_OVERHEAD * 1, "a3");
         stats = pool.stats();
         assert.deepEqual(stats.free, { count: 1, size: 24 });
-        assert.deepEqual(stats.used, { count: 2, size: 24 });
-        assert.equal(stats.top, 56, "top4");
+        assert.deepEqual(stats.used, {
+            count: 2,
+            size: 24 + POOL_OVERHEAD + BLOCK_OVERHEAD * 0
+        });
+        assert.equal(
+            stats.top,
+            56 + (POOL_OVERHEAD + BLOCK_OVERHEAD * 2),
+            "top4"
+        );
 
         // join both free blocks
         assert(pool.free(b), "free b2");
 
         // extend free block + top
         b = pool.malloc(64);
-        assert.equal(b, 16, "b3");
+        assert.equal(b, 16 + (POOL_OVERHEAD + BLOCK_OVERHEAD * 2), "b3");
         stats = pool.stats();
         assert.deepEqual(stats.free, { count: 0, size: 0 });
-        assert.deepEqual(stats.used, { count: 2, size: 72 });
-        assert.equal(stats.top, 80, "top5");
+        assert.deepEqual(stats.used, { count: 2, size: 96 - BLOCK_OVERHEAD });
+        assert.equal(
+            stats.top,
+            80 + (POOL_OVERHEAD + BLOCK_OVERHEAD * 2),
+            "top5"
+        );
 
         // alloc below min size
         c = pool.malloc(1);
 
         // non-continous free chain
         assert(pool.free(c), "free c2");
-        assert.equal(stats.top, 80, "top6");
+        assert.equal(
+            stats.top,
+            80 + (POOL_OVERHEAD + BLOCK_OVERHEAD * 2),
+            "top6"
+        );
         assert(pool.free(a), "free a3");
         stats = pool.stats();
-        assert.deepEqual(stats.free, { count: 1, size: 8 });
-        assert.deepEqual(stats.used, { count: 1, size: 64 });
-        assert.equal(stats.top, 80, "top7");
+        assert.deepEqual(stats.free, { count: 1, size: 8 + BLOCK_OVERHEAD });
+        assert.deepEqual(stats.used, { count: 1, size: 64 + BLOCK_OVERHEAD });
+        assert.equal(
+            stats.top,
+            80 + (POOL_OVERHEAD + BLOCK_OVERHEAD * 2),
+            "top7"
+        );
 
         // alloc larger size to force walking free chain
         // and then alloc @ top (reuse block @ 80)
         a = pool.malloc(27);
-        assert.equal(a, 80, "a4");
+        assert.equal(a, 80 + (POOL_OVERHEAD + BLOCK_OVERHEAD * 3), "a4");
         stats = pool.stats();
-        assert.deepEqual(stats.free, { count: 1, size: 8 });
-        assert.deepEqual(stats.used, { count: 2, size: 96 });
-        assert.equal(stats.top, 80 + 32, "top8");
+        assert.deepEqual(stats.free, { count: 1, size: 8 + BLOCK_OVERHEAD });
+        assert.deepEqual(stats.used, {
+            count: 2,
+            size: 96 + BLOCK_OVERHEAD * 2
+        });
+        assert.equal(
+            stats.top,
+            80 + 32 + (POOL_OVERHEAD + BLOCK_OVERHEAD * 3),
+            "top8"
+        );
 
         assert(pool.free(a), "free a4");
         assert(pool.free(b), "free b3");
         stats = pool.stats();
         assert.deepEqual(stats.free, { count: 0, size: 0 });
         assert.deepEqual(stats.used, { count: 0, size: 0 });
-        assert.equal(stats.available, 256 - 8);
-        assert.equal(stats.top, 8, "top9");
+        assert.equal(stats.available, 256 - 8 - POOL_OVERHEAD);
+        assert.equal(stats.top, 8 + POOL_OVERHEAD, "top9");
 
         pool.freeAll();
         assert.deepEqual(pool.stats(), {
             free: { count: 0, size: 0 },
             used: { count: 0, size: 0 },
-            available: pool.buf.byteLength - 8,
+            available: pool.buf.byteLength - 8 - POOL_OVERHEAD,
             total: pool.buf.byteLength,
-            top: 8
+            top: 8 + POOL_OVERHEAD
         });
         pool.release();
     });
@@ -140,8 +180,16 @@ describe("malloc", () => {
         let b = pool.mallocAs(Type.F64, 3);
         assert(a instanceof Float32Array, "a type");
         assert(b instanceof Float64Array, "b type");
-        assert.equal(a!.byteOffset, 8, "a addr");
-        assert.equal(b!.byteOffset, 24, "b addr");
+        assert.equal(
+            a!.byteOffset,
+            8 + POOL_OVERHEAD + BLOCK_OVERHEAD,
+            "a addr"
+        );
+        assert.equal(
+            b!.byteOffset,
+            24 + POOL_OVERHEAD + BLOCK_OVERHEAD * 2,
+            "b addr"
+        );
         assert.equal(a!.length, 3, "a.length");
         assert.equal(b!.length, 3, "b.length");
         assert.equal(a!.byteLength, 12, "a bytes");
@@ -149,20 +197,27 @@ describe("malloc", () => {
         a!.set([1, 2, 3]);
         b!.set([10, 20, 30]);
         assert.deepEqual(
-            [...new Uint32Array(pool.buf, 8, 10)],
+            [...new Uint32Array(pool.buf, a!.byteOffset, 4)],
             [
                 // a
                 0x3f800000,
                 0x40000000,
                 0x40400000,
                 0,
+            ]
+        );
+        assert.deepEqual(
+            [...new Uint32Array(pool.buf, b!.byteOffset, 8)],
+            [
                 // b
                 0,
                 0x40240000,
                 0,
                 0x40340000,
                 0,
-                0x403e0000
+                0x403e0000,
+                0,
+                0
             ]
         );
         assert(pool.free(a!), "free a");
@@ -173,8 +228,8 @@ describe("malloc", () => {
     });
 
     it("calloc", () => {
-        const u8 = (<any>pool).u8;
-        u8.fill(0xff);
+        const u8: Uint8Array = (<any>pool).u8;
+        u8.fill(0xff, 24);
         let a = pool.calloc(6);
         assert.deepEqual(
             [...u8.subarray(a, a + 9)],
@@ -217,42 +272,55 @@ describe("malloc", () => {
         pool.free(c);
     });
 
-    it("realloc");
+    it("realloc", () => {
+        const ma1 = pool.malloc(8);
+
+        const { size, addr }: MemBlock = (pool as any)._used as MemBlock;
+
+        assert.equal(size, 16);
+
+        pool.realloc(ma1, 16);
+        const usedBlockAfterRealloc: MemBlock = (pool as any)._used;
+
+        assert.equal(usedBlockAfterRealloc.addr, addr);
+        assert.equal(usedBlockAfterRealloc.size, size);
+    });
 
     it("no compact", () => {
         pool = new MemPool({ size: 0x100, compact: false });
-        pool.malloc(8);
-        pool.malloc(8);
-        pool.malloc(8);
-        pool.free(8);
-        pool.free(16);
-        pool.free(24);
+        const a = pool.malloc(8);
+        const a1 = pool.malloc(8);
+        const a2 = pool.malloc(8);
+        pool.free(a);
+        pool.free(a1);
+        pool.free(a2);
         let p: any = pool;
-        assert.equal(p._free.addr, 8);
-        assert.equal(p._free.next.addr, 16);
-        assert.equal(p._free.next.next.addr, 24);
+        assert.equal(p._free.addr + BLOCK_OVERHEAD, a);
+        assert.equal(p._free.next.addr + BLOCK_OVERHEAD, a1);
+        assert.equal(p._free.next.next.addr + BLOCK_OVERHEAD, a2);
         assert.equal(p._free.next.next.next, null);
     });
 
     it("no split", () => {
         pool = new MemPool({ size: 0x100, split: true });
-        pool.malloc(32);
+        const a1 = pool.malloc(32);
         pool.malloc(8);
-        pool.free(8);
+        pool.free(a1);
         pool.malloc(8);
         let p: any = pool;
-        assert.equal(p._used.addr, 8);
-        assert.equal(p._used.size, 8);
-        assert.equal(p._free.addr, 16);
+        assert.equal(p._used.addr, 8 + POOL_OVERHEAD);
+        assert.equal(p._used.size, 8 + BLOCK_OVERHEAD);
+        assert.equal(p._free.addr, 16 + POOL_OVERHEAD + BLOCK_OVERHEAD);
         assert.equal(p._free.size, 24);
+
         pool = new MemPool({ size: 0x100, split: false });
         pool.malloc(32);
         pool.malloc(8);
-        pool.free(8);
+        pool.free(8 + POOL_OVERHEAD + BLOCK_OVERHEAD);
         pool.malloc(8);
         p = pool;
-        assert.equal(p._used.addr, 8);
-        assert.equal(p._used.size, 32);
+        assert.equal(p._used.addr, 8 + POOL_OVERHEAD);
+        assert.equal(p._used.size, 32 + BLOCK_OVERHEAD);
         assert.equal(p._free, null);
     });
 });


### PR DESCRIPTION
See #138 

Overview:
ArrayBuffer size is now limited to 4GB, due use of uint32 as internal pointers.
We may use BigInt64, but it has other implications.

each block has 8 bytes overhead to save the size of the block, and pointer to the next block.

Mempool pointers variables (end, top, _free, _used) are now getters/setters, that saves the value onto the arraybuffer itself, into a known offset from the `start`
`start` is not saved into the arraybuffer, as its the anchor point we start to read from.
```ts
    protected get top(): number {
        return this.dataView.getUint32(this.start + POINTER_TOP_OFFSET);
    }

    protected set top(value: number) {
        this.dataView.setUint32(this.start + POINTER_TOP_OFFSET, value);
    }

    protected get _free(): MemBlock | null {
        const freeAddress = this.dataView.getUint32(this.start + POINTER_FREE_OFFSET);

        if (freeAddress == 0) {
            return null;
        }

        return new MemBlockWrapper(this.dataView, freeAddress);
    }
```

MemBlock is now implemented by a class with getters and setters, to read/write the next, size, from the arraybuffer
```ts
    public get next(): MemBlock | null {
        if (this.nextAddress !== 0) {
            return new MemBlockWrapper(this.dataView, this.nextAddress);
        }

        return null;
    }

    public set next(value: MemBlock | null) {
        this.nextAddress = value ? value.addr : 0;
    }

    public get size() {
        return this.dataView.getUint32(this.addr + MEM_BLOCK_SIZE_OFFSET)
    }

    public set size(value: number) {
        this.dataView.setUint32(this.addr + MEM_BLOCK_SIZE_OFFSET, value)
    }
```

* it was a bit painful to run, and update the tests,
i would recommend switching to jest/more modern way to running mocha (see the package.json diff)
I didn't update some of the "snapshot" tests yet. i can do that after the changes are finalised

* These changes does not change the public API of the library, but it imposes the 4GB limit, and adds not small overhead of 8 bytes per block.
Maybe it should be a separate library?

* We may swap the `MemBlockWrapper` and MemBlock interface with functional-pointer based impl.
I believe it will be more performant, with much less allocations on the javascript size

