### PR TITLE
WebGL1 depth texture

### DIFF
--- a/packages/webgl/src/api/texture.ts
+++ b/packages/webgl/src/api/texture.ts
@@ -179,10 +179,10 @@ export const TEX_FORMATS: IObjectOf<TextureFormatDecl> = {
         true
     ),
     [TextureFormat.DEPTH_COMPONENT]: $(
-      TextureFormat.DEPTH_COMPONENT,
-      [TextureType.UNSIGNED_SHORT, 2, TextureType.UNSIGNED_INT, 4],
-      1,
-      true
+        TextureFormat.DEPTH_COMPONENT,
+        [TextureType.UNSIGNED_SHORT, 2, TextureType.UNSIGNED_INT, 4],
+        1,
+        true
     ),
     [TextureFormat.DEPTH_COMPONENT16]: $(
         TextureFormat.DEPTH_COMPONENT,
@@ -199,6 +199,12 @@ export const TEX_FORMATS: IObjectOf<TextureFormatDecl> = {
     [TextureFormat.DEPTH_COMPONENT32F]: $(
         TextureFormat.DEPTH_COMPONENT,
         [TextureType.FLOAT, 4],
+        1,
+        true
+    ),
+    [TextureFormat.DEPTH_STENCIL]: $(
+        TextureFormat.DEPTH_STENCIL,
+        [TextureType.UNSIGNED_INT_24_8, 4],
         1,
         true
     ),

--- a/packages/webgl/src/api/texture.ts
+++ b/packages/webgl/src/api/texture.ts
@@ -178,6 +178,12 @@ export const TEX_FORMATS: IObjectOf<TextureFormatDecl> = {
         true,
         true
     ),
+    [TextureFormat.DEPTH_COMPONENT]: $(
+      TextureFormat.DEPTH_COMPONENT,
+      [TextureType.UNSIGNED_SHORT, 2, TextureType.UNSIGNED_INT, 4],
+      1,
+      true
+    ),
     [TextureFormat.DEPTH_COMPONENT16]: $(
         TextureFormat.DEPTH_COMPONENT,
         [TextureType.UNSIGNED_SHORT, 2, TextureType.UNSIGNED_INT, 4],


### PR DESCRIPTION
Hi, I think there is a missing `TextureFormat` use case for depth texture in WebGL1. By enabling the [`WEBGL_depth_texture`](https://developer.mozilla.org/en-US/docs/Web/API/WEBGL_depth_texture), you can pass `gl.DEPTH_COMPONENT` to both the `internalformat` and `format` arguments of [`gl.texImage2D()`](https://developer.mozilla.org/zh-CN/docs/Web/API/WebGLRenderingContext/texImage2D) as below

```javascript
gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 512, 512, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_SHORT, null);
```