### PR TITLE
fix(transducers): #186, Fix crash when using empty string as source for several transducers

### DIFF
--- a/packages/transducers/src/xform/benchmark.ts
+++ b/packages/transducers/src/xform/benchmark.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator1 } from "../iterator";
 import type { Reducer, Transducer } from "../api";
@@ -21,7 +22,7 @@ import type { Reducer, Transducer } from "../api";
 export function benchmark(): Transducer<any, number>;
 export function benchmark(src: Iterable<any>): IterableIterator<number>;
 export function benchmark(src?: Iterable<any>): any {
-    return src
+    return isIterable(src)
         ? iterator1(benchmark(), src)
         : (rfn: Reducer<any, number>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/drop-nth.ts
+++ b/packages/transducers/src/xform/drop-nth.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { iterator1 } from "../iterator";
 import { throttle } from "./throttle";
 import type { Transducer } from "../api";
@@ -5,7 +6,7 @@ import type { Transducer } from "../api";
 export function dropNth<T>(n: number): Transducer<T, T>;
 export function dropNth<T>(n: number, src: Iterable<T>): IterableIterator<T>;
 export function dropNth<T>(n: number, src?: Iterable<T>): any {
-    if (src) {
+    if (isIterable(src)) {
         return iterator1(dropNth(n), src);
     }
     n = Math.max(0, n - 1);

--- a/packages/transducers/src/xform/drop.ts
+++ b/packages/transducers/src/xform/drop.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator1 } from "../iterator";
 import type { Reducer, Transducer } from "../api";
@@ -5,7 +6,7 @@ import type { Reducer, Transducer } from "../api";
 export function drop<T>(n: number): Transducer<T, T>;
 export function drop<T>(n: number, src: Iterable<T>): IterableIterator<T>;
 export function drop<T>(n: number, src?: Iterable<T>): any {
-    return src
+  return isIterable(src)
         ? iterator1(drop(n), src)
         : (rfn: Reducer<any, T>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/duplicate.ts
+++ b/packages/transducers/src/xform/duplicate.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator } from "../iterator";
 import { isReduced } from "../reduced";
@@ -6,7 +7,7 @@ import type { Reducer, Transducer } from "../api";
 export function duplicate<T>(n?: number): Transducer<T, T>;
 export function duplicate<T>(n: number, src: Iterable<T>): IterableIterator<T>;
 export function duplicate<T>(n = 1, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator(duplicate(n), src)
         : (rfn: Reducer<any, T>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/filter.ts
+++ b/packages/transducers/src/xform/filter.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator1 } from "../iterator";
 import type { Predicate } from "@thi.ng/api";
@@ -9,7 +10,7 @@ export function filter<T>(
     src: Iterable<T>
 ): IterableIterator<T>;
 export function filter<T>(pred: Predicate<T>, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator1(filter(pred), src)
         : (rfn: Reducer<any, T>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/flatten-with.ts
+++ b/packages/transducers/src/xform/flatten-with.ts
@@ -1,3 +1,4 @@
+import { isIterable, isString } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator } from "../iterator";
 import { isReduced } from "../reduced";
@@ -15,8 +16,8 @@ export function flattenWith<T>(
     fn: Fn<T, Iterable<T>>,
     src?: Iterable<T | Iterable<T>>
 ): any {
-    return src
-        ? iterator(flattenWith(fn), src)
+    return isIterable(src)
+        ? iterator(flattenWith(fn), isString(src) ? <any>[src] : src)
         : (rfn: Reducer<any, T>) => {
               const reduce = rfn[2];
               const flatten = (acc: any, x: any) => {

--- a/packages/transducers/src/xform/interleave.ts
+++ b/packages/transducers/src/xform/interleave.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator } from "../iterator";
 import { isReduced } from "../reduced";
@@ -10,7 +11,7 @@ export function interleave<A, B>(
     src: Iterable<A>
 ): IterableIterator<A | B>;
 export function interleave<A, B>(sep: any, src?: Iterable<A>): any {
-    return src
+    return isIterable(src)
         ? iterator(interleave(sep), src)
         : (rfn: Reducer<any, A | B>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/interpolate.ts
+++ b/packages/transducers/src/xform/interpolate.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { comp } from "../func/comp";
 import { normRange } from "../iter/norm-range";
 import { iterator } from "../iterator";
@@ -51,7 +52,7 @@ export function interpolate<T>(fn: Fn2<T[], number, T>, window: number, n: numbe
 export function interpolate<T>(fn: Fn2<T[], number, T>, window: number, n: number, src: Iterable<number>): IterableIterator<number>;
 // prettier-ignore
 export function interpolate<T>(fn: Fn2<T[], number, T>, window: number, n: number, src?: Iterable<number>) {
-    return src
+  return isIterable(src)
         ? iterator(interpolate(fn, window, n), src)
         : comp(
               partition<T>(window, 1),

--- a/packages/transducers/src/xform/interpose.ts
+++ b/packages/transducers/src/xform/interpose.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator } from "../iterator";
 import { isReduced } from "../reduced";
@@ -10,7 +11,7 @@ export function interpose<A, B>(
     src: Iterable<A>
 ): IterableIterator<A | B>;
 export function interpose<A, B>(sep: any, src?: Iterable<A>): any {
-    return src
+    return isIterable(src)
         ? iterator(interpose(sep), src)
         : (rfn: Reducer<any, A | B>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/labeled.ts
+++ b/packages/transducers/src/xform/labeled.ts
@@ -1,4 +1,4 @@
-import { isFunction } from "@thi.ng/checks";
+import { isFunction, isIterable } from "@thi.ng/checks";
 import { iterator1 } from "../iterator";
 import { map } from "./map";
 import type { Transducer } from "../api";
@@ -11,7 +11,7 @@ export function labeled<L, T>(
     src: Iterable<T>
 ): IterableIterator<[L, T]>;
 export function labeled<L, T>(id: LabelFn<L, T>, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator1(labeled(id), src)
         : map(isFunction(id) ? (x: T) => [id(x), x] : (x: T) => [id, x]);
 }

--- a/packages/transducers/src/xform/map-deep.ts
+++ b/packages/transducers/src/xform/map-deep.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { deepTransform } from "../func/deep-transform";
 import { iterator1 } from "../iterator";
 import { map } from "./map";
@@ -17,5 +18,7 @@ export function mapDeep(
     src: Iterable<any>
 ): IterableIterator<any>;
 export function mapDeep(spec: TransformSpec, src?: Iterable<any>): any {
-    return src ? iterator1(mapDeep(spec), src) : map(deepTransform(spec));
+    return isIterable(src)
+        ? iterator1(mapDeep(spec), src)
+        : map(deepTransform(spec));
 }

--- a/packages/transducers/src/xform/map.ts
+++ b/packages/transducers/src/xform/map.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator1 } from "../iterator";
 import type { Fn } from "@thi.ng/api";
@@ -18,7 +19,7 @@ import type { Reducer, Transducer } from "../api";
 export function map<A, B>(fn: Fn<A, B>): Transducer<A, B>;
 export function map<A, B>(fn: Fn<A, B>, src: Iterable<A>): IterableIterator<B>;
 export function map<A, B>(fn: Fn<A, B>, src?: Iterable<A>): any {
-    return src
+    return isIterable(src)
         ? iterator1(map(fn), src)
         : (rfn: Reducer<any, B>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/mapcat.ts
+++ b/packages/transducers/src/xform/mapcat.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { comp } from "../func/comp";
 import { iterator } from "../iterator";
 import { cat } from "./cat";
@@ -33,5 +34,5 @@ export function mapcat<A, B>(
     fn: Fn<A, Iterable<B> | null | undefined>,
     src?: Iterable<A>
 ): any {
-    return src ? iterator(mapcat(fn), src) : comp(map(fn), cat());
+    return isIterable(src) ? iterator(mapcat(fn), src) : comp(map(fn), cat());
 }

--- a/packages/transducers/src/xform/match-first.ts
+++ b/packages/transducers/src/xform/match-first.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { comp } from "../func/comp";
 import { iterator1 } from "../iterator";
 import { filter } from "./filter";
@@ -41,7 +42,7 @@ export function matchFirst<T>(
     src: Iterable<T>
 ): T | undefined;
 export function matchFirst<T>(pred: Predicate<T>, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? [...iterator1(matchFirst(pred), src)][0]
         : comp(filter(pred), take(1));
 }

--- a/packages/transducers/src/xform/match-last.ts
+++ b/packages/transducers/src/xform/match-last.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { comp } from "../func/comp";
 import { iterator } from "../iterator";
 import { filter } from "./filter";
@@ -41,7 +42,7 @@ export function matchLast<T>(
     src: Iterable<T>
 ): T | undefined;
 export function matchLast<T>(pred: Predicate<T>, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? [...iterator(matchLast(pred), src)][0]
         : comp(filter(pred), takeLast(1));
 }

--- a/packages/transducers/src/xform/moving-average.ts
+++ b/packages/transducers/src/xform/moving-average.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { illegalArgs } from "@thi.ng/errors";
 import { compR } from "../func/compr";
 import { iterator1 } from "../iterator";
@@ -24,7 +25,7 @@ export function movingAverage(period: number): Transducer<number, number>;
 // prettier-ignore
 export function movingAverage(period: number, src: Iterable<number>): IterableIterator<number>;
 export function movingAverage(period: number, src?: Iterable<number>): any {
-    return src
+    return isIterable(src)
         ? iterator1(movingAverage(period), src)
         : (rfn: Reducer<any, number>) => {
               period |= 0;

--- a/packages/transducers/src/xform/pad-last.ts
+++ b/packages/transducers/src/xform/pad-last.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { iterator } from "../iterator";
 import { isReduced } from "../reduced";
 import type { Reducer, Transducer } from "../api";
@@ -41,7 +42,7 @@ export function padLast<T>(
     src: Iterable<T>
 ): IterableIterator<T>;
 export function padLast<T>(n: number, fill: T, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator(padLast(n, fill), src)
         : ([init, complete, reduce]: Reducer<any, T>) => {
               let m = 0;

--- a/packages/transducers/src/xform/partition-of.ts
+++ b/packages/transducers/src/xform/partition-of.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { iterator } from "../iterator";
 import { partitionBy } from "./partition-by";
 import type { Transducer } from "../api";
@@ -26,7 +27,7 @@ export function partitionOf<T>(
     src: Iterable<T>
 ): IterableIterator<T[]>;
 export function partitionOf<T>(sizes: number[], src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator(partitionOf(sizes), src)
         : partitionBy(() => {
               let i = 0,

--- a/packages/transducers/src/xform/partition-time.ts
+++ b/packages/transducers/src/xform/partition-time.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { iterator } from "../iterator";
 import { partitionBy } from "./partition-by";
 import type { Transducer } from "../api";
@@ -38,7 +39,7 @@ export function partitionTime<T>(
     src: Iterable<T>
 ): IterableIterator<T[]>;
 export function partitionTime<T>(period: number, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator(partitionTime(period), src)
         : partitionBy(() => {
               let last = 0;

--- a/packages/transducers/src/xform/pluck.ts
+++ b/packages/transducers/src/xform/pluck.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { iterator1 } from "../iterator";
 import { map } from "./map";
 import type { Transducer } from "../api";
@@ -20,5 +21,7 @@ export function pluck<A, B>(
     src: Iterable<A>
 ): IterableIterator<B>;
 export function pluck<A>(key: PropertyKey, src?: Iterable<A>): any {
-    return src ? iterator1(pluck(key), src) : map((x: any) => x[key]);
+    return isIterable(src)
+        ? iterator1(pluck(key), src)
+        : map((x: any) => x[key]);
 }

--- a/packages/transducers/src/xform/select-keys.ts
+++ b/packages/transducers/src/xform/select-keys.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { keySelector } from "../func/key-selector";
 import { iterator1 } from "../iterator";
 import { map } from "./map";
@@ -33,5 +34,7 @@ export function selectKeys<T>(
     src: Iterable<T>
 ): IterableIterator<any>;
 export function selectKeys<T>(keys: PropertyKey[], src?: Iterable<T>): any {
-    return src ? iterator1(selectKeys(keys), src) : map(keySelector(keys));
+    return isIterable(src)
+        ? iterator1(selectKeys(keys), src)
+        : map(keySelector(keys));
 }

--- a/packages/transducers/src/xform/struct.ts
+++ b/packages/transducers/src/xform/struct.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { comp } from "../func/comp";
 import { iterator } from "../iterator";
 import { mapKeys } from "./map-keys";
@@ -52,7 +53,7 @@ export function struct<T>(
     src: Iterable<any>
 ): IterableIterator<T>;
 export function struct(fields: StructField[], src?: Iterable<any>): any {
-    return src
+    return isIterable(src)
         ? iterator(struct(fields), src)
         : comp(
               partitionOf(fields.map((f) => f[1])),

--- a/packages/transducers/src/xform/swizzle.ts
+++ b/packages/transducers/src/xform/swizzle.ts
@@ -1,4 +1,5 @@
 import { swizzle as _swizzle } from "@thi.ng/arrays";
+import { isIterable } from "@thi.ng/checks";
 import { iterator1 } from "../iterator";
 import { map } from "./map";
 import type { Transducer } from "../api";
@@ -30,5 +31,7 @@ export function swizzle<T>(
     src: Iterable<any>
 ): IterableIterator<any[]>;
 export function swizzle(order: PropertyKey[], src?: Iterable<any>): any {
-    return src ? iterator1(swizzle(order), src) : map(_swizzle(order));
+    return isIterable(src)
+        ? iterator1(swizzle(order), src)
+        : map(_swizzle(order));
 }

--- a/packages/transducers/src/xform/take-last.ts
+++ b/packages/transducers/src/xform/take-last.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { __drain } from "../internal/drain";
 import { iterator } from "../iterator";
 import type { Reducer, Transducer } from "../api";
@@ -18,7 +19,7 @@ import type { Reducer, Transducer } from "../api";
 export function takeLast<T>(n: number): Transducer<T, T>;
 export function takeLast<T>(n: number, src: Iterable<T>): IterableIterator<T>;
 export function takeLast<T>(n: number, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator(takeLast(n), src)
         : ([init, complete, reduce]: Reducer<any, T>) => {
               const buf: T[] = [];

--- a/packages/transducers/src/xform/take-nth.ts
+++ b/packages/transducers/src/xform/take-nth.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { iterator1 } from "../iterator";
 import { throttle } from "./throttle";
 import type { Transducer } from "../api";
@@ -17,7 +18,7 @@ import type { Transducer } from "../api";
 export function takeNth<T>(n: number): Transducer<T, T>;
 export function takeNth<T>(n: number, src: Iterable<T>): IterableIterator<T>;
 export function takeNth<T>(n: number, src?: Iterable<T>): any {
-    if (src) {
+    if (isIterable(src)) {
         return iterator1(takeNth(n), src);
     }
     n = Math.max(0, n - 1);

--- a/packages/transducers/src/xform/take.ts
+++ b/packages/transducers/src/xform/take.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator } from "../iterator";
 import { ensureReduced, reduced } from "../reduced";
@@ -18,7 +19,7 @@ import type { Reducer, Transducer } from "../api";
 export function take<T>(n: number): Transducer<T, T>;
 export function take<T>(n: number, src: Iterable<T>): IterableIterator<T>;
 export function take<T>(n: number, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator(take(n), src)
         : (rfn: Reducer<any, T>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/throttle-time.ts
+++ b/packages/transducers/src/xform/throttle-time.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { iterator1 } from "../iterator";
 import { throttle } from "./throttle";
 import type { Transducer } from "../api";
@@ -22,7 +23,7 @@ export function throttleTime<T>(
     src: Iterable<T>
 ): IterableIterator<T>;
 export function throttleTime<T>(delay: number, src?: Iterable<T>): any {
-    return src
+    return isIterable(src)
         ? iterator1(throttleTime(delay), src)
         : throttle<T>(() => {
               let last = 0;

--- a/packages/transducers/src/xform/throttle.ts
+++ b/packages/transducers/src/xform/throttle.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { compR } from "../func/compr";
 import { iterator1 } from "../iterator";
 import type { StatefulPredicate } from "@thi.ng/api";
@@ -29,7 +30,7 @@ export function throttle<T>(
     pred: StatefulPredicate<T>,
     src?: Iterable<T>
 ): any {
-    return src
+    return isIterable(src)
         ? iterator1(throttle(pred), src)
         : (rfn: Reducer<any, T>) => {
               const r = rfn[2];

--- a/packages/transducers/src/xform/toggle.ts
+++ b/packages/transducers/src/xform/toggle.ts
@@ -1,3 +1,4 @@
+import { isIterable } from "@thi.ng/checks";
 import { iterator1 } from "../iterator";
 import type { Reducer, Transducer } from "../api";
 
@@ -33,7 +34,7 @@ export function toggle<T>(
     initial = false,
     src?: Iterable<any>
 ): any {
-    return src
+    return isIterable(src)
         ? iterator1(toggle(on, off, initial), src)
         : ([init, complete, reduce]: Reducer<any, T>) => {
               let state = initial;

--- a/packages/transducers/test/drop.ts
+++ b/packages/transducers/test/drop.ts
@@ -1,0 +1,21 @@
+import { drop, range } from "../src";
+
+import * as assert from "assert";
+
+describe("drop", () => {
+    it("starts iterating after N items", () => {
+        assert.deepEqual([...drop(0, [true, false])], [true, false]);
+        assert.deepEqual([...drop(1, [true, false])], [false]);
+        assert.deepEqual([...drop(2, [true, false])], []);
+        assert.deepEqual([...drop(3, [true, false])], []);
+        assert.deepEqual([...drop(2, range(0, 4))], [2, 3]);
+        assert.deepEqual([...drop(0, ["", "ab", "c"])], ["", "ab", "c"]);
+        assert.deepEqual([...drop(1, ["", "ab", "c"])], ["ab", "c"]);
+        assert.deepEqual([...drop(2, ["", "ab", "c"])], ["c"]);
+        assert.deepEqual([...drop(0, "")], []);
+        assert.deepEqual([...drop(1, "")], []);
+        assert.deepEqual([...drop(0, "abc")], ["a", "b", "c"]);
+        assert.deepEqual([...drop(1, "abc")], ["b", "c"]);
+        assert.deepEqual([...drop(2, "abc")], ["c"]);
+    });
+});

--- a/packages/transducers/test/filter.ts
+++ b/packages/transducers/test/filter.ts
@@ -1,0 +1,31 @@
+import { filter, range } from "../src";
+
+import * as assert from "assert";
+
+describe("filter", () => {
+    const identity = (x: any) => x;
+    const always = () => true;
+    const never = () => false;
+    const vowel = (s: string) => /[aeiou]/.test(s);
+    const even = (n: number) => n % 2 === 0;
+
+    it("applies predicate over iterable and forwards values testing truthy", () => {
+        assert.deepEqual(
+            [...filter(identity, [true, false, "a", "", 0, 1, []])],
+            [true, "a", 1, []]
+        );
+        assert.deepEqual(
+            [...filter(always, [true, false, "a", "", 0, 1, []])],
+            [true, false, "a", "", 0, 1, []]
+        );
+        assert.deepEqual(
+            [...filter(never, [true, false, "a", "", 0, 1, []])],
+            []
+        );
+        assert.deepEqual([...filter(vowel, ["", "a", "bc"])], ["a"]);
+        assert.deepEqual([...filter(even, range(1, 5))], [2, 4]);
+        assert.deepEqual([...filter(always, "")], []);
+        assert.deepEqual([...filter(always, "abc")], ["a", "b", "c"]);
+        assert.deepEqual([...filter(vowel, "abc")], ["a"]);
+    });
+});

--- a/packages/transducers/test/flatten.ts
+++ b/packages/transducers/test/flatten.ts
@@ -14,6 +14,11 @@ describe("flatten", () => {
     it("strings", () => {
         assert.deepEqual([...flatten(["", "a"])], ["", "a"]);
         assert.deepEqual([...flatten([[], ["a"], ""])], ["a", ""]);
+        assert.deepEqual([...flatten([["abc"]])], ["abc"]);
+        assert.deepEqual([...flatten(["abc"])], ["abc"]);
+        assert.deepEqual([...flatten("abc")], ["abc"]);
+        assert.deepEqual([...flatten([""])], [""]);
+        assert.deepEqual([...flatten("")], [""]);
     });
     it("iterators", () => {
         assert.deepEqual([...flatten(range(0))], []);

--- a/packages/transducers/test/map.ts
+++ b/packages/transducers/test/map.ts
@@ -1,0 +1,18 @@
+import { map, range } from "../src";
+
+import * as assert from "assert";
+
+describe("map", () => {
+    const identity = <T>(t: T): T => t;
+    const upper = (s: string) => s.toUpperCase();
+    const square = (n: number) => n * n;
+
+    it("applies function over iterable", () => {
+        assert.deepEqual([...map(identity, [])], []);
+        assert.deepEqual([...map(identity, ["", "ab", "c"])], ["", "ab", "c"]);
+        assert.deepEqual([...map(upper, ["", "ab", "c"])], ["", "AB", "C"]);
+        assert.deepEqual([...map(square, range(1, 4))], [1, 4, 9]);
+        assert.deepEqual([...map(upper, "")], []);
+        assert.deepEqual([...map(upper, "abc")], ["A", "B", "C"]);
+    });
+});

--- a/packages/transducers/test/take.ts
+++ b/packages/transducers/test/take.ts
@@ -1,0 +1,21 @@
+import { take, range } from "../src";
+
+import * as assert from "assert";
+
+describe("take", () => {
+    it("iterates up to N items", () => {
+        assert.deepEqual([...take(0, [true, false])], []);
+        assert.deepEqual([...take(1, [true, false])], [true]);
+        assert.deepEqual([...take(2, [true, false])], [true, false]);
+        assert.deepEqual([...take(3, [true, false])], [true, false]);
+        assert.deepEqual([...take(2, range(0, 4))], [0, 1]);
+        assert.deepEqual([...take(0, ["", "ab", "c"])], []);
+        assert.deepEqual([...take(1, ["", "ab", "c"])], [""]);
+        assert.deepEqual([...take(2, ["", "ab", "c"])], ["", "ab"]);
+        assert.deepEqual([...take(0, "")], []);
+        assert.deepEqual([...take(1, "")], []);
+        assert.deepEqual([...take(0, "abc")], []);
+        assert.deepEqual([...take(1, "abc")], ["a"]);
+        assert.deepEqual([...take(2, "abc")], ["a", "b"]);
+    });
+});


### PR DESCRIPTION
Includes tests for _some_ of the affected transducers.

**NOTE**: This _changes the behavior_ of `flatten` when a string is passed as the source argument (per discussion in issue).

Fixes #186