### PR TITLE
feat(rstream-gestures): use string value enum for debugging

### DIFF
--- a/packages/rstream-gestures/src/api.ts
+++ b/packages/rstream-gestures/src/api.ts
@@ -16,11 +16,11 @@ export type UIEventID =
     | "wheel";
 
 export enum GestureType {
-    START,
-    MOVE,
-    DRAG,
-    END,
-    ZOOM,
+    START = "START",
+    MOVE = "MOVE",
+    DRAG = "DRAG",
+    END = "END",
+    ZOOM = "ZOOM",
 }
 
 export interface GestureInfo {


### PR DESCRIPTION
Add string values to the GestureType enum. Trade off between easier
debugging vs. maintainability. With only five values and this package
being stable, this seems worthwhile.
