### PR TITLE
Fix components folder include for ecs

### DIFF
--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -65,7 +65,7 @@
         "*.d.ts",
         "lib",
         "caches",
-        "component",
+        "components",
         "groups"
     ],
     "keywords": [


### PR DESCRIPTION
A beautiful 1 character pull request...

The @thi.ng/ecs package doesn't seem to publish the components folder:

```
Module not found: Error: Can't resolve './components/object-component'
```

Seems a typo was introduced around 0.3.34...  removing the s!

