### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/packages/checks/src/index.ts
+++ b/packages/checks/src/index.ts
@@ -49,6 +49,7 @@ export * from "./is-positive";
 export * from "./is-primitive";
 export * from "./is-promise";
 export * from "./is-promiselike";
+export * from "./is-prototype-polluted";
 export * from "./is-regexp";
 export * from "./is-safari";
 export * from "./is-set";

--- a/packages/checks/src/is-prototype-polluted.ts
+++ b/packages/checks/src/is-prototype-polluted.ts
@@ -1,1 +1,2 @@
-export const isPrototypePolluted = (key: string): Boolean => ['__proto__', 'prototype', 'constructor'].includes(key);
+const ILLEGAL_KEYS = new Set(["__proto__", "prototype", "constructor"]);
+export const isPrototypePolluted = (key: string): Boolean => ILLEGAL_KEYS.includes(key);

--- a/packages/checks/src/is-prototype-polluted.ts
+++ b/packages/checks/src/is-prototype-polluted.ts
@@ -1,0 +1,1 @@
+export const isPrototypePolluted = (key: string): Boolean => ['__proto__', 'prototype', 'constructor'].includes(key);

--- a/packages/checks/src/is-prototype-polluted.ts
+++ b/packages/checks/src/is-prototype-polluted.ts
@@ -1,2 +1,2 @@
 const ILLEGAL_KEYS = new Set(["__proto__", "prototype", "constructor"]);
-export const isPrototypePolluted = (key: string): Boolean => ILLEGAL_KEYS.includes(key);
+export const isPrototypePolluted = (key: string): Boolean => ILLEGAL_KEYS.has(key);

--- a/packages/paths/src/mutator.ts
+++ b/packages/paths/src/mutator.ts
@@ -13,7 +13,7 @@ import type {
     Path8,
     PathVal,
 } from "@thi.ng/api";
-import { toPath } from "./path";
+import { disallowProtoPath, toPath } from "./path";
 
 /**
  * Unchecked version of {@link defMutator}.
@@ -73,6 +73,7 @@ export function defMutator<T, A, B, C, D, E, F, G, H>(
 ): Fn2<T, any, any>;
 export function defMutator(path: Path): any {
     const ks = toPath(path);
+    disallowProtoPath(ks);
     let [a, b, c, d] = ks;
     switch (ks.length) {
         case 0:

--- a/packages/paths/src/path.ts
+++ b/packages/paths/src/path.ts
@@ -1,5 +1,5 @@
 import { assert, NumOrString, Path } from "@thi.ng/api";
-import { isArray, isString } from "@thi.ng/checks";
+import { isArray, isString, isPrototypePolluted } from "@thi.ng/checks";
 
 /**
  * Converts the given key path to canonical form (array).
@@ -66,9 +66,9 @@ export const exists = (obj: any, path: Path) => {
  */
 export const isProtoPath = (path: Path) =>
     isArray(path)
-        ? path.some((x) => x === "__proto__")
+        ? path.some((x) => isPrototypePolluted(x))
         : isString(path)
-        ? path.indexOf("__proto__") >= 0
+        ? isPrototypePolluted(path)
         : false;
 
 /**

--- a/packages/paths/test/index.ts
+++ b/packages/paths/test/index.ts
@@ -1,5 +1,5 @@
 import * as assert from "assert";
-import { exists, getIn, getInUnsafe, setIn, setInUnsafe } from "../src";
+import { exists, getIn, getInUnsafe, mutIn, setIn, setInUnsafe } from "../src";
 
 describe("paths", () => {
     it("getIn", () => {
@@ -183,4 +183,9 @@ describe("paths", () => {
         assert.ok(!exists(b, "x.y.z.3.u"), "x.y.z.3.u");
         assert.ok(!exists(b, "x.z.y.2.u"), "x.z.y.2.u");
     });
+
+    it("mutIn", () => {
+      const a: any = {};
+      assert.throws(() => mutIn(a, ['__proto__', 'polluted'], true))
+    })
 });


### PR DESCRIPTION
@d3v53c (https://huntr.dev/users/d3v53c) has fixed a potential Prototype Pollution vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/umbrella/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/@thi.ng/paths/1/README.md

### User Comments:

### 📊 Metadata *

@thi.ng/paths is vulnerable to Prototype Pollution. The vulnerability is due to an incomplete fix. mutIn() function does not have fix implemented.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-%40thi.ng%2Fpaths/

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *


    Create the following PoC file:

```
// poc.js
const paths = require('@thi.ng/paths')

console.log("Before: ", {}.polluted")
paths.mutIn({}, ['__proto__','polluted'], true)
console.log("After: ", {}.polluted)
```

    Execute the following commands in the terminal:

```
npm i @thi.ng/paths # install vulnerable package
node poc.js # run the PoC
```

    Check the output:

```
Before: undefined
After: true
```

### 🔥 Proof of Fix (PoF) *

Before:
![image](https://user-images.githubusercontent.com/64132745/105844919-fb290200-5fff-11eb-9a40-0dbec30567b9.png)

After:
![image](https://user-images.githubusercontent.com/64132745/105843273-7f2dba80-5ffd-11eb-8143-6a59e44cb78f.png)

### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/105863380-d7bd8180-6016-11eb-965b-35a7aa077296.png)

After the fix, functionality is unaffected.

### 🔗 Relates to...

https://github.com/418sec/huntr/pull/1785
