### PR TITLE
Fixed bug which was resulting in recursion

### DIFF
--- a/packages/zipper/src/zipper.ts
+++ b/packages/zipper/src/zipper.ts
@@ -195,7 +195,7 @@ export class Location<T> {
         if (!node) return this.up;
         while (true) {
             const child: Location<T> | undefined = node!.isBranch
-                ? this.down
+                ? node.down
                 : undefined;
             if (!child) return node;
             node = child.rightmost;


### PR DESCRIPTION
Fixed bug resulting in recursion while traversing in a loop in reverse direction. (prev)

Looping through the tree using prev property results in recursion. On checking checking it seems a typo.