### PR TITLE
Update Voronoi readme to use randNormS2 instead of randNorm2

### DIFF
--- a/packages/geom-voronoi/tpl.readme.md
+++ b/packages/geom-voronoi/tpl.readme.md
@@ -56,9 +56,9 @@ ${docLink}
 import * as g from "@thi.ng/geom";
 import { DVMesh } from "@thi.ng/geom-voronoi";
 import { repeatedly } from "@thi.ng/transducers";
-import { randNorm2 } from "@thi.ng/vectors";
+import { randNormS2 } from "@thi.ng/vectors";
 
-const pts = [...repeatedly(() => randNorm2([], Math.random() * 250), 1000)];
+const pts = [...repeatedly(() => randNormS2([], Math.random() * 250), 1000)];
 
 const mesh = new DVMesh(pts);
 
@@ -67,7 +67,7 @@ mesh.delaunay()
 mesh.voronoi()
 
 // ...or clipped & filtered polygons within convex polygon boundary
-const bounds = g.vertices(g.center(g.rect(500)));
+const bounds = g.vertices(g.center(g.rect(500))!);
 // [ [ -250, -250 ], [ 250, -250 ], [ 250, 250 ], [ -250, 250 ] ]
 
 const cells = mesh.voronoi(bounds);


### PR DESCRIPTION
I guess this function was moved/ renamed in `vectors` since the API example in the voronoi readme was written. In any case this patch gets the example running.

Per the contributor docs, I tried to update the readme itself from the template with:

    yarn lerna run doc:readme --scope "@thi.ng/geom-voronoi"

But I got the error:

> lerna ERR! yarn run doc:readme stderr:
> shasum: ../../assets/banners/thing-geom-voronoi.svg: 
> error Command failed with exit code 1.

I assume the banner assets live outside of the umbrella repository somewhere. At least I couldn't see that file/ directory anywhere so I assume it's not just a path/ configuration problem at my end. 