### PR TITLE
Configurable vector distance function for KdTreeMap and KdTreeSet

### DIFF
--- a/packages/geom-accel/src/kd-tree-map.ts
+++ b/packages/geom-accel/src/kd-tree-map.ts
@@ -50,12 +50,12 @@ export class KdTreeMap<K extends ReadonlyVec, V>
 
     protected root: MaybeKdNode<K, V>;
     protected _size: number;
-    protected _distFn: DistanceFn;
+    protected _distanceFn: DistanceFn;
 
-    constructor(dim: number, pairs?: Iterable<Pair<K, V>>, distFn?: DistanceFn) {
+    constructor(dim: number, pairs?: Iterable<Pair<K, V>>, distanceFn: DistanceFn = distSq) {
         this.dim = dim;
         this._size = 0;
-        this._distFn = distFn || distSq;
+        this._distanceFn = distanceFn;
         this.root = pairs ? this.buildTree(ensureArray(pairs), 0) : undefined;
     }
 
@@ -97,8 +97,12 @@ export class KdTreeMap<K extends ReadonlyVec, V>
         return this._size ? this.height / Math.log2(this._size) : 0;
     }
 
+    get distanceFn() {
+        return this._distanceFn;
+    }
+
     copy() {
-        return new KdTreeMap(this.dim, this);
+        return new KdTreeMap(this.dim, this, this._distanceFn);
     }
 
     clear() {
@@ -107,7 +111,7 @@ export class KdTreeMap<K extends ReadonlyVec, V>
     }
 
     empty() {
-        return new KdTreeMap<K, V>(this.dim);
+        return new KdTreeMap<K, V>(this.dim, undefined, this._distanceFn);
     }
 
     set(key: K, val: V, eps = EPS) {
@@ -122,7 +126,7 @@ export class KdTreeMap<K extends ReadonlyVec, V>
                 : parent;
         let parent: MaybeKdNode<K, V>;
         if (this.root) {
-            parent = nearest1(key, [eps, undefined], this.dim, this.root, this._distFn)[1];
+            parent = nearest1(key, [eps, undefined], this.dim, this.root, this._distanceFn)[1];
             if (parent) {
                 parent.v = val;
                 return false;
@@ -159,7 +163,7 @@ export class KdTreeMap<K extends ReadonlyVec, V>
     has(key: K, eps = EPS) {
         return (
             !!this.root &&
-            !!nearest1(key, [eps * eps, undefined], this.dim, this.root, this._distFn)[1]
+            !!nearest1(key, [eps * eps, undefined], this.dim, this.root, this._distanceFn)[1]
         );
     }
 
@@ -170,7 +174,7 @@ export class KdTreeMap<K extends ReadonlyVec, V>
                 [eps * eps, undefined],
                 this.dim,
                 this.root,
-                this._distFn
+                this._distanceFn
             )[1];
             return node ? node.v : undefined;
         }
@@ -208,7 +212,7 @@ export class KdTreeMap<K extends ReadonlyVec, V>
                 [maxDist, undefined],
                 this.dim,
                 this.root,
-                this._distFn
+                this._distanceFn
             )[1];
             sel && acc.push(f(sel));
         } else {
@@ -218,7 +222,7 @@ export class KdTreeMap<K extends ReadonlyVec, V>
                     compare: CMP,
                 }
             );
-            nearest(q, nodes, this.dim, maxNum, this.root!, this._distFn);
+            nearest(q, nodes, this.dim, maxNum, this.root!, this._distanceFn);
             return addResults(f, nodes.values, acc);
         }
         return acc;

--- a/packages/geom-accel/src/kd-tree-set.ts
+++ b/packages/geom-accel/src/kd-tree-set.ts
@@ -1,6 +1,6 @@
 import type { ICopy, IEmpty, Pair } from "@thi.ng/api";
 import type { IRegionQuery, ISpatialSet } from "@thi.ng/geom-api";
-import type { ReadonlyVec } from "@thi.ng/vectors";
+import type { DistanceFn, ReadonlyVec } from "@thi.ng/vectors";
 import { KdTreeMap } from "./kd-tree-map.js";
 
 export class KdTreeSet<K extends ReadonlyVec>
@@ -12,8 +12,8 @@ export class KdTreeSet<K extends ReadonlyVec>
 {
     protected tree: KdTreeMap<K, K>;
 
-    constructor(dim: number, keys?: Iterable<K>) {
-        this.tree = new KdTreeMap(dim);
+    constructor(dim: number, keys?: Iterable<K>, distanceFn?: DistanceFn) {
+        this.tree = new KdTreeMap(dim, undefined, distanceFn);
         keys && this.into(keys);
     }
 
@@ -42,7 +42,7 @@ export class KdTreeSet<K extends ReadonlyVec>
     }
 
     copy() {
-        return new KdTreeSet<K>(this.tree.dim, this);
+        return new KdTreeSet<K>(this.tree.dim, this, this.tree.distanceFn);
     }
 
     clear() {
@@ -50,7 +50,7 @@ export class KdTreeSet<K extends ReadonlyVec>
     }
 
     empty() {
-        return new KdTreeSet<K>(this.tree.dim);
+        return new KdTreeSet<K>(this.tree.dim, undefined, this.tree.distanceFn);
     }
 
     add(key: K, eps?: number) {

--- a/packages/geom-accel/test/kdtree.ts
+++ b/packages/geom-accel/test/kdtree.ts
@@ -1,0 +1,61 @@
+import { group } from "@thi.ng/testament";
+import { mapIndexed } from "@thi.ng/transducers";
+import { distHaversineLatLon, ReadonlyVec } from "@thi.ng/vectors";
+import * as assert from "assert";
+import { KdTreeMap } from "../src/index.js"
+
+const pts3D = new Set<ReadonlyVec>([
+    [10, 20, 30],
+    [60, 70, 80],
+    [44, 55, 66],
+]);
+
+const pairs3D = new Set(mapIndexed((i, p) => <[ReadonlyVec, number]>[p, i], pts3D));
+
+const pts2D = new Set<ReadonlyVec>([
+    [0, 0],
+    [85, 0],
+    [70, 180],
+    [-90, 45],
+]);
+
+const pairs2D = new Set(mapIndexed((i, p) => <[ReadonlyVec, number]>[p, i], pts2D));
+
+let tree: KdTreeMap<ReadonlyVec, any>;
+
+group(
+    "KdTree - 3D",
+    {
+        ctor: () => {
+            assert.deepEqual(tree.dim, 3);
+            assert.deepEqual(tree.height, 2);
+        },
+    },
+    {
+        beforeEach: () => {
+            tree = new KdTreeMap(3, pairs3D);
+        }
+    }
+);
+
+group(
+    "KdTree - 2D",
+    {
+        ctor: () => {
+            assert.deepEqual(tree.dim, 2);
+            assert.deepEqual(tree.height, 3);
+        },
+        query: () => {
+            assert.deepEqual(tree.query([85, 180], Infinity, 1), [[[70, 180], 2]]);
+        },
+        "haversine tree / query": () => {
+            tree = new KdTreeMap(2, pairs2D, distHaversineLatLon);
+            assert.deepEqual(tree.query([85, 180], Infinity, 1), [[[85, 0], 1]]);
+        }
+    },
+    {
+        beforeEach: () => {
+            tree = new KdTreeMap(2, pairs2D);
+        }
+    }
+);

--- a/packages/geom-accel/test/kdtree.ts
+++ b/packages/geom-accel/test/kdtree.ts
@@ -2,7 +2,7 @@ import { group } from "@thi.ng/testament";
 import { mapIndexed } from "@thi.ng/transducers";
 import { distHaversineLatLon, ReadonlyVec } from "@thi.ng/vectors";
 import * as assert from "assert";
-import { KdTreeMap } from "../src/index.js"
+import { KdTreeMap } from "../src/index.js";
 
 const pts3D = new Set<ReadonlyVec>([
     [10, 20, 30],

--- a/packages/geom-accel/test/kdtree.ts
+++ b/packages/geom-accel/test/kdtree.ts
@@ -2,7 +2,7 @@ import { group } from "@thi.ng/testament";
 import { mapIndexed } from "@thi.ng/transducers";
 import { distHaversineLatLon, ReadonlyVec } from "@thi.ng/vectors";
 import * as assert from "assert";
-import { KdTreeMap } from "../src/index.js";
+import { KdTreeMap, KdTreeSet } from "../src/index.js";
 
 const pts3D = new Set<ReadonlyVec>([
     [10, 20, 30],
@@ -21,41 +21,64 @@ const pts2D = new Set<ReadonlyVec>([
 
 const pairs2D = new Set(mapIndexed((i, p) => <[ReadonlyVec, number]>[p, i], pts2D));
 
-let tree: KdTreeMap<ReadonlyVec, any>;
+let treeMap: KdTreeMap<ReadonlyVec, any>;
+let treeSet: KdTreeSet<ReadonlyVec>;
 
 group(
-    "KdTree - 3D",
+    "KdTreeMap - 3D",
     {
         ctor: () => {
-            assert.deepEqual(tree.dim, 3);
-            assert.deepEqual(tree.height, 2);
+            assert.deepEqual(treeMap.dim, 3);
+            assert.deepEqual(treeMap.height, 2);
         },
     },
     {
         beforeEach: () => {
-            tree = new KdTreeMap(3, pairs3D);
+            treeMap = new KdTreeMap(3, pairs3D);
         }
     }
 );
 
 group(
-    "KdTree - 2D",
+    "KdTreeMap - 2D",
     {
         ctor: () => {
-            assert.deepEqual(tree.dim, 2);
-            assert.deepEqual(tree.height, 3);
+            assert.deepEqual(treeMap.dim, 2);
+            assert.deepEqual(treeMap.height, 3);
+            assert.deepEqual(treeMap.size, 4);
         },
         query: () => {
-            assert.deepEqual(tree.query([85, 180], Infinity, 1), [[[70, 180], 2]]);
+            assert.deepEqual(treeMap.query([85, 180], Infinity, 1), [[[70, 180], 2]]);
         },
-        "haversine tree / query": () => {
-            tree = new KdTreeMap(2, pairs2D, distHaversineLatLon);
-            assert.deepEqual(tree.query([85, 180], Infinity, 1), [[[85, 0], 1]]);
+        "haversine distance / query": () => {
+            treeMap = new KdTreeMap(2, pairs2D, distHaversineLatLon);
+            assert.deepEqual(treeMap.query([85, 180], Infinity, 1), [[[85, 0], 1]]);
         }
     },
     {
         beforeEach: () => {
-            tree = new KdTreeMap(2, pairs2D);
+            treeMap = new KdTreeMap(2, pairs2D);
         }
     }
 );
+
+group(
+    "KdTreeSet - 2D",
+    {
+        ctor: () => {
+            assert.deepEqual(treeSet.size, 4);
+        },
+        query: () => {
+            assert.deepEqual(treeSet.query([85, 180], Infinity, 1), [[[70, 180], [70, 180]]]);
+        },
+        "haversine distance / query": () => {
+            treeSet = new KdTreeSet(2, pts2D, distHaversineLatLon);
+            assert.deepEqual(treeSet.query([85, 180], Infinity, 1), [[[85, 0], [85, 0]]]);
+        }
+    },
+    {
+        beforeEach: () => {
+            treeSet = new KdTreeSet(2, pts2D);
+        }
+    }
+)


### PR DESCRIPTION
I was hoping to take advantage of the KdTreeMap component from geom-accel to support lat/long (or long/lat) based indexing and queries, but the current implementation hardcodes the node distance calculation to vectors/distSq so it doesn't properly handle distances that cross the poles or +/-180 longitude. This PR adds the ability to override the distance function used by KdTreeMap or KdTreeSet to use a different vector distance function (such as vector/distHaversineLatLon) as a drop in replacement.

Added some unit tests for KdTreeMap/KdTreeSet to demonstrate that query works as expected with the default behavior, but properly handles nearest point for spherical coordinates if you specify a haversine distance calculation.