### PR TITLE
Update EventListener and RAFListener in wasm-api-dom to allow storing a anyopaque pointer

### DIFF
--- a/examples/zig-canvas/zig/main.zig
+++ b/examples/zig-canvas/zig/main.zig
@@ -28,7 +28,7 @@ var canvasID: i32 = -1;
 // event handlers
 
 /// mousedown/touchstart handler
-fn startStroke(event: *const dom.Event) void {
+fn startStroke(event: *const dom.Event, _: ?*anyopaque) void {
     var stroke: *Stroke = WASM_ALLOCATOR.create(Stroke) catch return;
     var strokeInst = std.ArrayList(Point).init(WASM_ALLOCATOR);
     strokeInst.append(scaledPoint(event.clientX, event.clientY)) catch return;
@@ -38,7 +38,7 @@ fn startStroke(event: *const dom.Event) void {
 }
 
 /// mousemove/touchmove handler (only if active stroke)
-fn updateStroke(event: *const dom.Event) void {
+fn updateStroke(event: *const dom.Event, _: ?*anyopaque) void {
     if (currStroke) |curr| {
         curr.append(scaledPoint(event.clientX, event.clientY)) catch return;
         dom.preventDefault();
@@ -47,7 +47,7 @@ fn updateStroke(event: *const dom.Event) void {
 }
 
 /// mouseup/touchend handler
-fn endStroke(_: *const dom.Event) void {
+fn endStroke(_: *const dom.Event, _: ?*anyopaque) void {
     currStroke = null;
 }
 
@@ -59,7 +59,7 @@ fn scaledPoint(x: i16, y: i16) Point {
     };
 }
 
-fn onKeyDown(event: *const dom.Event) void {
+fn onKeyDown(event: *const dom.Event, _: ?*anyopaque) void {
     if (event.modifiers & @enumToInt(dom.KeyModifier.CTRL) == 0) return;
     const key = event.getKey();
     if (std.mem.eql(u8, key, "z")) {
@@ -68,16 +68,16 @@ fn onKeyDown(event: *const dom.Event) void {
     }
 }
 
-fn onResize(_: *const dom.Event) void {
+fn onResize(_: *const dom.Event, _: ?*anyopaque) void {
     resizeCanvas();
     requestRedraw();
 }
 
-fn onBtUndo(_: *const dom.Event) void {
+fn onBtUndo(_: *const dom.Event, _: ?*anyopaque) void {
     undoStroke();
 }
 
-fn onBtDownload(_: *const dom.Event) void {
+fn onBtDownload(_: *const dom.Event, _: ?*anyopaque) void {
     downloadCanvas(canvasID);
 }
 
@@ -95,11 +95,11 @@ fn resizeCanvas() void {
 /// Triggers redraw during next RAF cycle. This app redraws on demand,
 /// but we NEVER want to do so from the event loop!
 fn requestRedraw() void {
-    _ = dom.requestAnimationFrame(redraw) catch return;
+    _ = dom.requestAnimationFrame(.{ .callback = redraw }) catch return;
 }
 
 /// Redraw handler, calls into JS API to draw to canvas
-fn redraw(_: f64) void {
+fn redraw(_: f64, _: ?*anyopaque) void {
     clearCanvas(canvasID);
     for (strokes.items) |stroke| {
         drawStroke(canvasID, stroke.items.ptr, stroke.items.len);
@@ -146,14 +146,14 @@ fn initDOM() anyerror!void {
         .class = "mr1",
         .parent = toolbar,
     });
-    _ = try dom.addListener(btUndo, "click", onBtUndo);
+    _ = try dom.addListener(btUndo, "click", .{ .callback = onBtUndo });
 
     const btDownload = dom.createElement(&.{
         .tag = "button",
         .text = "download",
         .parent = toolbar,
     });
-    _ = try dom.addListener(btDownload, "click", onBtDownload);
+    _ = try dom.addListener(btDownload, "click", .{ .callback = onBtDownload });
 
     // main editor canvas
     canvasID = dom.createCanvas(&.{
@@ -166,16 +166,16 @@ fn initDOM() anyerror!void {
     });
     resizeCanvas();
 
-    _ = try dom.addListener(canvasID, "mousedown", startStroke);
-    _ = try dom.addListener(canvasID, "mousemove", updateStroke);
-    _ = try dom.addListener(canvasID, "mouseup", endStroke);
+    _ = try dom.addListener(canvasID, "mousedown", .{ .callback = startStroke });
+    _ = try dom.addListener(canvasID, "mousemove", .{ .callback = updateStroke });
+    _ = try dom.addListener(canvasID, "mouseup", .{ .callback = endStroke });
 
-    _ = try dom.addListener(canvasID, "touchstart", startStroke);
-    _ = try dom.addListener(canvasID, "touchmove", updateStroke);
-    _ = try dom.addListener(canvasID, "touchend", endStroke);
+    _ = try dom.addListener(canvasID, "touchstart", .{ .callback = startStroke });
+    _ = try dom.addListener(canvasID, "touchmove", .{ .callback = updateStroke });
+    _ = try dom.addListener(canvasID, "touchend", .{ .callback = endStroke });
 
-    _ = try dom.addListener(dom.WINDOW, "keydown", onKeyDown);
-    _ = try dom.addListener(dom.WINDOW, "resize", onResize);
+    _ = try dom.addListener(dom.WINDOW, "keydown", .{ .callback = onKeyDown });
+    _ = try dom.addListener(dom.WINDOW, "resize", .{ .callback = onResize });
 }
 
 /// Main entry point (called from JS)


### PR DESCRIPTION
This PR:
- implements #355 for EventListener and RAFListener
- changes reuseOrAddSlot since it was not working with the changes to EventListener and RAFListener
- refactors zig-canvas example to reflect changes to EventListener and RAFListener