### PR TITLE
FIX/packages/wasm-api-canvas/package.json: incl. zig/ + generated/

### DIFF
--- a/packages/wasm-api-canvas/package.json
+++ b/packages/wasm-api-canvas/package.json
@@ -64,7 +64,9 @@
 	},
 	"files": [
 		"./*.js",
-		"./*.d.ts"
+		"./*.d.ts",
+    "zig",
+    "generated"
 	],
 	"exports": {
 		".": {


### PR DESCRIPTION
Looks like "files" needs to include the zig/ and generated/ directories to provide all the necesarry sources when adding the wasm-api-canvas package in via `yarn add @thi.ng/wasm-api-canvas`.