### PR TITLE
fix: add @thi.ng/date dependency to axidraw

### DIFF
--- a/packages/axidraw/package.json
+++ b/packages/axidraw/package.json
@@ -37,6 +37,7 @@
 		"@thi.ng/api": "^8.6.3",
 		"@thi.ng/checks": "^3.3.7",
 		"@thi.ng/compose": "^2.1.24",
+		"@thi.ng/date": "^2.4.1",
 		"@thi.ng/errors": "^2.2.8",
 		"@thi.ng/logger": "^1.4.7",
 		"@thi.ng/vectors": "^7.5.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2449,6 +2449,7 @@ __metadata:
     "@thi.ng/api": ^8.6.3
     "@thi.ng/checks": ^3.3.7
     "@thi.ng/compose": ^2.1.24
+    "@thi.ng/date": ^2.4.1
     "@thi.ng/errors": ^2.2.8
     "@thi.ng/logger": ^1.4.7
     "@thi.ng/testament": ^0.3.9


### PR DESCRIPTION
I tried running the example for @thi.ng/axidraw.

It errored because of a missing dependency `@th.ing/date`
That dependency is used on that line: https://github.com/thi-ng/umbrella/blob/develop/packages/axidraw/src/axidraw.ts#L4

This PR is just to add that missing dependency to @thi.ng/axidraw