### PR TITLE
fix(hiccup-css): allow negative values for px

### DIFF
--- a/packages/hiccup-css/src/units.ts
+++ b/packages/hiccup-css/src/units.ts
@@ -2,7 +2,7 @@ export const em = (x: number) => `${x}em`;
 export const ex = (x: number) => `${x}ex`;
 export const rem = (x: number) => `${x}rem`;
 export const percent = (x: number) => `${x}%`;
-export const px = (x: number) => `${x >>> 0}px`;
+export const px = (x: number) => `${x | 0}px`;
 export const vh = (x: number) => `${x}vh`;
 export const vw = (x: number) => `${x}vw`;
 


### PR DESCRIPTION
Swap use of unsigned shift for OR `0`

Fixes issue #383

Example use case: 
```ts
const MARGIN_PX = -10;
const cmp = div({ style: "margin-left": px(MARGIN) }, "Hi");
```