### PR TITLE
build: update bench pkg file (update clean cmd)

### DIFF
--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -25,7 +25,7 @@
 	"license": "Apache-2.0",
 	"scripts": {
 		"build": "yarn clean && tsc --declaration",
-		"clean": "rimraf '*.js' '*.d.ts' '*.map' doc format",
+		"clean": "rimraf --glob '*.js' '*.d.ts' '*.map' doc format",
 		"doc": "typedoc --excludePrivate --excludeInternal --out doc src/index.ts",
 		"doc:ae": "mkdir -p .ae/doc .ae/temp && api-extractor run --local --verbose",
 		"doc:readme": "yarn doc:stats && tools:readme",


### PR DESCRIPTION
Very small fix. The bench package file was missed when updating the clean command, and adding the glob argument to the rimraf command. Package would not build on Windows.