### PR TITLE
Use hash from global $fx object

### DIFF
--- a/packages/random-fxhash/src/index.ts
+++ b/packages/random-fxhash/src/index.ts
@@ -43,7 +43,9 @@ export const seedFromHash = (hash: string) =>
 		);
 
 let seed: number[];
-if (typeof $fx?.hash === "string") {
+if (typeof fxhash === "string") {
+	seed = seedFromHash(fxhash);
+} else if (typeof $fx?.hash === "string") {
 	seed = seedFromHash($fx.hash);
 } else {
 	seed = DEFAULT_SEED_128;

--- a/packages/random-fxhash/src/index.ts
+++ b/packages/random-fxhash/src/index.ts
@@ -43,8 +43,8 @@ export const seedFromHash = (hash: string) =>
 		);
 
 let seed: number[];
-if (typeof fxhash === "string") {
-	seed = seedFromHash(fxhash);
+if (typeof $fx?.hash === "string") {
+	seed = seedFromHash($fx.hash);
 } else {
 	seed = DEFAULT_SEED_128;
 	console.warn("fxhash PRNG not found, using default seed", seed, "\n\n");


### PR DESCRIPTION
The [latest version](https://github.com/fxhash/fxhash-package/blob/main/packages/project-sdk/dist/fxhash.js) of the fxhash snippet (now called project SDK) no longer exposes a global `fxhash` variable. Instead, we should use `$fx.hash` ([See Usage section in documentation](https://www.fxhash.xyz/doc/artist/project-sdk)).

I added a check to support the new recommended method and kept the old one for backward compatibility.

Once this is merged, I'd be happy to send a PR to update the [tpl-umbrella-fxhash](https://github.com/thi-ng/tpl-umbrella-fxhash) project to use the new SDK (looks to be quite outdated, as the snippet in the index.html does not support fxparams).