### PR TITLE
[shader-ast] Allow type inference of defn with arbitrary number of arguments

### DIFF
--- a/packages/shader-ast-stdlib/src/math/additive.ts
+++ b/packages/shader-ast-stdlib/src/math/additive.ts
@@ -49,11 +49,11 @@ export const additive = <T extends Prim>(
 						n,
 						add(
 							n,
-							mul(amp, fn(<any>add(<any>pos, mul(i, <any>shift))))
+							mul(amp, fn(add(pos, mul(i, shift))))
 						)
 					),
 					assign(amp, mul(amp, decay)),
-					assign(pos, <any>mul(<any>pos, 2)),
+					assign(pos, mul(pos, 2)),
 				]
 			),
 			ret(n),

--- a/packages/shader-ast-stdlib/src/math/magsq.ts
+++ b/packages/shader-ast-stdlib/src/math/magsq.ts
@@ -3,8 +3,8 @@ import { F } from "@thi.ng/shader-ast/api/types";
 import { defn, ret } from "@thi.ng/shader-ast/ast/function";
 import { dot } from "@thi.ng/shader-ast/builtin/math";
 
-const $ = (n: 2 | 3 | 4) =>
-	defn(F, `magSq${n}`, [<any>`vec${n}`], (v) => [ret(dot(v, v))]);
+const $ = <N extends 2 | 3 | 4>(n: N) =>
+	defn(F, `magSq${n}`, [`vec${n}`], (v) => [ret(dot(v, v))]);
 
 export const magSq2: TaggedFn1<"vec2", "float"> = $(2);
 export const magSq3: TaggedFn1<"vec3", "float"> = $(3);

--- a/packages/shader-ast-stdlib/src/math/mix-cubic.ts
+++ b/packages/shader-ast-stdlib/src/math/mix-cubic.ts
@@ -21,12 +21,12 @@ const $ = <N extends 1 | 2 | 3 | 4, T extends PrimTypeMap[N]>(n: N, type: T) =>
 					add(
 						add(
 							add(
-								mul(<any>a, mul(s, s2)),
-								mul(<any>b, mul(3, mul(s2, t)))
+								mul(a, mul(s, s2)),
+								mul(b, mul(3, mul(s2, t)))
 							),
-							mul(<any>c, mul(3, mul(t2, s)))
+							mul(c, mul(3, mul(t2, s)))
 						),
-						mul(<any>d, mul(t, t2))
+						mul(d, mul(t, t2))
 					)
 				),
 			];

--- a/packages/shader-ast-stdlib/src/math/mix-quadratic.ts
+++ b/packages/shader-ast-stdlib/src/math/mix-quadratic.ts
@@ -16,10 +16,10 @@ const $ = <N extends 1 | 2 | 3 | 4, T extends PrimTypeMap[N]>(n: N, type: T) =>
 				ret(
 					add(
 						add(
-							mul(<any>a, mul(s, s)),
-							mul(<any>b, mul(2, mul(s, t)))
+							mul(a, mul(s, s)),
+							mul(b, mul(2, mul(s, t)))
 						),
-						mul(<any>c, mul(t, t))
+						mul(c, mul(t, t))
 					)
 				),
 			];

--- a/packages/shader-ast-stdlib/src/noise/permute.ts
+++ b/packages/shader-ast-stdlib/src/noise/permute.ts
@@ -7,7 +7,7 @@ import { mod } from "@thi.ng/shader-ast/builtin/math";
 
 const __permute = <T extends Prim>(type: T, suffix = "") =>
 	defn(type, `permute${suffix}`, [type], (v) => [
-		ret(mod(mul(<any>v, add(mul(<any>v, float(34)), FLOAT1)), float(289))),
+		ret(mod(mul(v, add(mul(v, float(34)), FLOAT1)), float(289))),
 	]);
 
 export const permute = __permute(F);

--- a/packages/shader-ast-stdlib/src/sdf/line.ts
+++ b/packages/shader-ast-stdlib/src/sdf/line.ts
@@ -1,4 +1,4 @@
-import type { PrimTypeMap, Sym } from "@thi.ng/shader-ast";
+import type { PrimTypeMap } from "@thi.ng/shader-ast";
 import { F, V2, V3 } from "@thi.ng/shader-ast/api/types";
 import { defn, ret } from "@thi.ng/shader-ast/ast/function";
 import { div, mul, sub } from "@thi.ng/shader-ast/ast/ops";
@@ -15,10 +15,11 @@ import { clamp01 } from "../math/clamp.js";
  */
 const $ = <N extends 2 | 3, T extends PrimTypeMap[N]>(n: N, type: T) =>
 	defn(F, `sdLine${n}`, [type, type, type], (p, a, b) => {
-		let pa: Sym<T>, ba: Sym<T>;
+		const pa = sym(sub(p, a));
+		const ba = sym(sub(b, a));
 		return [
-			(pa = sym(sub(p, a))),
-			(ba = sym(sub(b, a))),
+			pa,
+			ba,
 			ret(
 				length(sub(pa, mul(ba, clamp01(div(dot(pa, ba), dot(ba, ba))))))
 			),

--- a/packages/shader-ast/src/api/function.ts
+++ b/packages/shader-ast/src/api/function.ts
@@ -1,4 +1,3 @@
-import type { Fn, Fn0, Fn2, Fn3, Fn4, Fn5, Fn6, Fn7, Fn8 } from "@thi.ng/api";
 import type { FnCall, Sym, Term } from "./nodes.js";
 import type { SymOpts } from "./syms.js";
 import type { Type } from "./types.js";
@@ -7,31 +6,30 @@ export type ScopeBody = (Term<any> | null | undefined)[];
 
 export type Arg<A extends Type> = A | [A, string?, SymOpts?];
 
-export type Arg1<A extends Type> = [Arg<A>];
-
-export type Arg2<A extends Type, B extends Type> = [Arg<A>, Arg<B>];
-
-export type Arg3<A extends Type, B extends Type, C extends Type> = [
-	Arg<A>,
-	Arg<B>,
-	Arg<C>
-];
-
+/** @deprecated */
+export type Arg1<A extends Type> = VariadicArgs<[A]>;
+/** @deprecated */
+export type Arg2<A extends Type, B extends Type> = VariadicArgs<[A, B]>;
+/** @deprecated */
+export type Arg3<A extends Type, B extends Type, C extends Type> = VariadicArgs<
+	[A, B, C]
+>;
+/** @deprecated */
 export type Arg4<
 	A extends Type,
 	B extends Type,
 	C extends Type,
 	D extends Type
-> = [Arg<A>, Arg<B>, Arg<C>, Arg<D>];
-
+> = VariadicArgs<[A, B, C, D]>;
+/** @deprecated */
 export type Arg5<
 	A extends Type,
 	B extends Type,
 	C extends Type,
 	D extends Type,
 	E extends Type
-> = [Arg<A>, Arg<B>, Arg<C>, Arg<D>, Arg<E>];
-
+> = VariadicArgs<[A, B, C, D, E]>;
+/** @deprecated */
 export type Arg6<
 	A extends Type,
 	B extends Type,
@@ -39,8 +37,8 @@ export type Arg6<
 	D extends Type,
 	E extends Type,
 	F extends Type
-> = [Arg<A>, Arg<B>, Arg<C>, Arg<D>, Arg<E>, Arg<F>];
-
+> = VariadicArgs<[A, B, C, D, E, F]>;
+/** @deprecated */
 export type Arg7<
 	A extends Type,
 	B extends Type,
@@ -49,8 +47,8 @@ export type Arg7<
 	E extends Type,
 	F extends Type,
 	G extends Type
-> = [Arg<A>, Arg<B>, Arg<C>, Arg<D>, Arg<E>, Arg<F>, Arg<G>];
-
+> = VariadicArgs<[A, B, C, D, E, F, G]>;
+/** @deprecated */
 export type Arg8<
 	A extends Type,
 	B extends Type,
@@ -60,40 +58,34 @@ export type Arg8<
 	F extends Type,
 	G extends Type,
 	H extends Type
-> = [Arg<A>, Arg<B>, Arg<C>, Arg<D>, Arg<E>, Arg<F>, Arg<G>, Arg<H>];
+> = VariadicArgs<[A, B, C, D, E, F, G, H]>;
 
-export type FnBody0 = Fn0<ScopeBody>;
-
-export type FnBody1<A extends Type> = Fn<Sym<A>, ScopeBody>;
-
-export type FnBody2<A extends Type, B extends Type> = Fn2<
-	Sym<A>,
-	Sym<B>,
-	ScopeBody
->;
-
-export type FnBody3<A extends Type, B extends Type, C extends Type> = Fn3<
-	Sym<A>,
-	Sym<B>,
-	Sym<C>,
-	ScopeBody
->;
-
+export type FnBody0 = VariadicFnBody<[]>;
+export type FnBody1<A extends Type> = VariadicFnBody<[A]>;
+/** @deprecated */
+export type FnBody2<A extends Type, B extends Type> = VariadicFnBody<[A, B]>;
+/** @deprecated */
+export type FnBody3<
+	A extends Type,
+	B extends Type,
+	C extends Type
+> = VariadicFnBody<[A, B, C]>;
+/** @deprecated */
 export type FnBody4<
 	A extends Type,
 	B extends Type,
 	C extends Type,
 	D extends Type
-> = Fn4<Sym<A>, Sym<B>, Sym<C>, Sym<D>, ScopeBody>;
-
+> = VariadicFnBody<[A, B, C, D]>;
+/** @deprecated */
 export type FnBody5<
 	A extends Type,
 	B extends Type,
 	C extends Type,
 	D extends Type,
 	E extends Type
-> = Fn5<Sym<A>, Sym<B>, Sym<C>, Sym<D>, Sym<E>, ScopeBody>;
-
+> = VariadicFnBody<[A, B, C, D, E]>;
+/** @deprecated */
 export type FnBody6<
 	A extends Type,
 	B extends Type,
@@ -101,8 +93,8 @@ export type FnBody6<
 	D extends Type,
 	E extends Type,
 	F extends Type
-> = Fn6<Sym<A>, Sym<B>, Sym<C>, Sym<D>, Sym<E>, Sym<F>, ScopeBody>;
-
+> = VariadicFnBody<[A, B, C, D, E, F]>;
+/** @deprecated */
 export type FnBody7<
 	A extends Type,
 	B extends Type,
@@ -111,8 +103,8 @@ export type FnBody7<
 	E extends Type,
 	F extends Type,
 	G extends Type
-> = Fn7<Sym<A>, Sym<B>, Sym<C>, Sym<D>, Sym<E>, Sym<F>, Sym<G>, ScopeBody>;
-
+> = VariadicFnBody<[A, B, C, D, E, F, G]>;
+/** @deprecated */
 export type FnBody8<
 	A extends Type,
 	B extends Type,
@@ -122,43 +114,34 @@ export type FnBody8<
 	F extends Type,
 	G extends Type,
 	H extends Type
-> = Fn8<
-	Sym<A>,
-	Sym<B>,
-	Sym<C>,
-	Sym<D>,
-	Sym<E>,
-	Sym<F>,
-	Sym<G>,
-	Sym<H>,
-	ScopeBody
->;
+> = VariadicFnBody<[A, B, C, D, E, F, G, H]>;
 
-export type Func0<T extends Type> = Fn0<FnCall<T>>;
-
-export type Func1<A extends Type, T extends Type> = Fn<Term<A>, FnCall<T>>;
-
-export type Func2<A extends Type, B extends Type, T extends Type> = Fn2<
-	Term<A>,
-	Term<B>,
-	FnCall<T>
->;
-
+/** @deprecated */
+export type Func0<T extends Type> = VariadicFunc<[], T>;
+/** @deprecated */
+export type Func1<A extends Type, T extends Type> = VariadicFunc<[A], T>;
+/** @deprecated */
+export type Func2<
+	A extends Type,
+	B extends Type,
+	T extends Type
+> = VariadicFunc<[A, B], T>;
+/** @deprecated */
 export type Func3<
 	A extends Type,
 	B extends Type,
 	C extends Type,
 	T extends Type
-> = Fn3<Term<A>, Term<B>, Term<C>, FnCall<T>>;
-
+> = VariadicFunc<[A, B, C], T>;
+/** @deprecated */
 export type Func4<
 	A extends Type,
 	B extends Type,
 	C extends Type,
 	D extends Type,
 	T extends Type
-> = Fn4<Term<A>, Term<B>, Term<C>, Term<D>, FnCall<T>>;
-
+> = VariadicFunc<[A, B, C, D], T>;
+/** @deprecated */
 export type Func5<
 	A extends Type,
 	B extends Type,
@@ -166,8 +149,8 @@ export type Func5<
 	D extends Type,
 	E extends Type,
 	T extends Type
-> = Fn5<Term<A>, Term<B>, Term<C>, Term<D>, Term<E>, FnCall<T>>;
-
+> = VariadicFunc<[A, B, C, D, E], T>;
+/** @deprecated */
 export type Func6<
 	A extends Type,
 	B extends Type,
@@ -176,8 +159,8 @@ export type Func6<
 	E extends Type,
 	F extends Type,
 	T extends Type
-> = Fn6<Term<A>, Term<B>, Term<C>, Term<D>, Term<E>, Term<F>, FnCall<T>>;
-
+> = VariadicFunc<[A, B, C, D, E, F], T>;
+/** @deprecated */
 export type Func7<
 	A extends Type,
 	B extends Type,
@@ -187,17 +170,8 @@ export type Func7<
 	F extends Type,
 	G extends Type,
 	T extends Type
-> = Fn7<
-	Term<A>,
-	Term<B>,
-	Term<C>,
-	Term<D>,
-	Term<E>,
-	Term<F>,
-	Term<G>,
-	FnCall<T>
->;
-
+> = VariadicFunc<[A, B, C, D, E, F, G], T>;
+/** @deprecated */
 export type Func8<
 	A extends Type,
 	B extends Type,
@@ -208,14 +182,25 @@ export type Func8<
 	G extends Type,
 	H extends Type,
 	T extends Type
-> = Fn8<
-	Term<A>,
-	Term<B>,
-	Term<C>,
-	Term<D>,
-	Term<E>,
-	Term<F>,
-	Term<G>,
-	Term<H>,
+> = VariadicFunc<[A, B, C, D, E, F, G, H], T>;
+
+export type VariadicFunc<Xs extends Type[], T extends Type> = VariadicFn<
+	VariadicTerms<Xs>,
 	FnCall<T>
 >;
+export type VariadicFnBody<Xs extends Type[]> = VariadicFn<
+	VariadicSyms<Xs>,
+	ScopeBody
+>;
+type VariadicFn<Xs extends unknown[], Y> = (...xs: Xs) => Y;
+export type VariadicArgs<Xs extends Type[]> = {
+	[i in keyof Xs]: Arg<Xs[i]>;
+};
+export type VariadicSyms<Xs extends Type[]> = {
+	[i in keyof Xs]: Sym<Xs[i]>;
+};
+export type VariadicTerms<Xs extends Type[]> = {
+	[i in keyof Xs]: Term<Xs[i]>;
+};
+type TypeOfArg<X> = X extends Arg<infer A> ? A : never;
+export type VariadicTypeOfArg<Xs extends unknown[]> = { [i in keyof Xs]: TypeOfArg<Xs[i]> };

--- a/packages/shader-ast/src/api/nodes.ts
+++ b/packages/shader-ast/src/api/nodes.ts
@@ -1,14 +1,4 @@
-import type {
-	Func0,
-	Func1,
-	Func2,
-	Func3,
-	Func4,
-	Func5,
-	Func6,
-	Func7,
-	Func8,
-} from "./function.js";
+import type { VariadicFunc as FuncVar, VariadicSyms } from "./function.js";
 import type { Operator } from "./ops.js";
 import type { SymOpts } from "./syms.js";
 import type { Tag } from "./tags.js";
@@ -115,43 +105,36 @@ export interface Func<T extends Type> extends Term<T>, Scoped {
 	deps: Func<any>[];
 }
 
-export interface TaggedFn0<T extends Type> extends Func0<T>, Func<T> {
-	args: [];
+export interface VariadicTaggedFn<Xs extends Type[], T extends Type>
+	extends FuncVar<Xs, T>,
+		Func<T> {
+	args: VariadicSyms<Xs>;
 }
 
+/** @deprecated */
+export interface TaggedFn0<T extends Type> extends VariadicTaggedFn<[], T> {}
+/** @deprecated */
 export interface TaggedFn1<A extends Type, T extends Type>
-	extends Func1<A, T>,
-		Func<T> {
-	args: [Sym<A>];
-}
-
+	extends VariadicTaggedFn<[A], T> {}
+/** @deprecated */
 export interface TaggedFn2<A extends Type, B extends Type, T extends Type>
-	extends Func2<A, B, T>,
-		Func<T> {
-	args: [Sym<A>, Sym<B>];
-}
-
+	extends VariadicTaggedFn<[A, B], T> {}
+/** @deprecated */
 export interface TaggedFn3<
 	A extends Type,
 	B extends Type,
 	C extends Type,
 	T extends Type
-> extends Func3<A, B, C, T>,
-		Func<T> {
-	args: [Sym<A>, Sym<B>, Sym<C>];
-}
-
+> extends VariadicTaggedFn<[A, B, C], T> {}
+/** @deprecated */
 export interface TaggedFn4<
 	A extends Type,
 	B extends Type,
 	C extends Type,
 	D extends Type,
 	T extends Type
-> extends Func4<A, B, C, D, T>,
-		Func<T> {
-	args: [Sym<A>, Sym<B>, Sym<C>, Sym<D>];
-}
-
+> extends VariadicTaggedFn<[A, B, C, D], T> {}
+/** @deprecated */
 export interface TaggedFn5<
 	A extends Type,
 	B extends Type,
@@ -159,11 +142,8 @@ export interface TaggedFn5<
 	D extends Type,
 	E extends Type,
 	T extends Type
-> extends Func5<A, B, C, D, E, T>,
-		Func<T> {
-	args: [Sym<A>, Sym<B>, Sym<C>, Sym<D>, Sym<E>];
-}
-
+> extends VariadicTaggedFn<[A, B, C, D, E], T> {}
+/** @deprecated */
 export interface TaggedFn6<
 	A extends Type,
 	B extends Type,
@@ -172,11 +152,8 @@ export interface TaggedFn6<
 	E extends Type,
 	F extends Type,
 	T extends Type
-> extends Func6<A, B, C, D, E, F, T>,
-		Func<T> {
-	args: [Sym<A>, Sym<B>, Sym<C>, Sym<D>, Sym<E>, Sym<F>];
-}
-
+> extends VariadicTaggedFn<[A, B, C, D, E, F], T> {}
+/** @deprecated */
 export interface TaggedFn7<
 	A extends Type,
 	B extends Type,
@@ -186,11 +163,8 @@ export interface TaggedFn7<
 	F extends Type,
 	G extends Type,
 	T extends Type
-> extends Func7<A, B, C, D, E, F, G, T>,
-		Func<T> {
-	args: [Sym<A>, Sym<B>, Sym<C>, Sym<D>, Sym<E>, Sym<F>, Sym<G>];
-}
-
+> extends VariadicTaggedFn<[A, B, C, D, E, F, G], T> {}
+/** @deprecated */
 export interface TaggedFn8<
 	A extends Type,
 	B extends Type,
@@ -201,10 +175,7 @@ export interface TaggedFn8<
 	G extends Type,
 	H extends Type,
 	T extends Type
-> extends Func8<A, B, C, D, E, F, G, H, T>,
-		Func<T> {
-	args: [Sym<A>, Sym<B>, Sym<C>, Sym<D>, Sym<E>, Sym<F>, Sym<G>, Sym<H>];
-}
+> extends VariadicTaggedFn<[A, B, C, D, E, F, G, H], T> {}
 
 export interface FnCall<T extends Type> extends Term<T> {
 	id: string;

--- a/packages/shader-ast/src/ast/function.ts
+++ b/packages/shader-ast/src/ast/function.ts
@@ -2,25 +2,13 @@ import type { Nullable } from "@thi.ng/api";
 import { isString } from "@thi.ng/checks/is-string";
 import { assert } from "@thi.ng/errors/assert";
 import type {
-	Arg,
-	Arg1,
-	Arg2,
-	Arg3,
-	Arg4,
-	Arg5,
-	Arg6,
-	Arg7,
-	Arg8,
-	FnBody0,
-	FnBody1,
-	FnBody2,
-	FnBody3,
-	FnBody4,
-	FnBody5,
-	FnBody6,
-	FnBody7,
-	FnBody8,
-	ScopeBody,
+    Arg,
+    VariadicArgs,
+    VariadicFnBody,
+    FnBody0,
+    ScopeBody,
+    VariadicTerms,
+    VariadicTypeOfArg,
 } from "../api/function.js";
 import type {
 	FnCall,
@@ -28,15 +16,7 @@ import type {
 	FuncArg,
 	FuncReturn,
 	Sym,
-	TaggedFn0,
-	TaggedFn1,
-	TaggedFn2,
-	TaggedFn3,
-	TaggedFn4,
-	TaggedFn5,
-	TaggedFn6,
-	TaggedFn7,
-	TaggedFn8,
+	VariadicTaggedFn,
 	Term,
 } from "../api/nodes.js";
 import type { SymOpts } from "../api/syms.js";
@@ -56,33 +36,23 @@ const defArg = <T extends Type>(a: Arg<T>): FuncArg<T> => {
 };
 
 /**
- * Defines a new function with up to 8 typed checked arguments.
+ * Defines a new function with variadic typed checked arguments.
  *
  * @param type - return type
  * @param name - function name
  * @param args - arg types / names / opts
  * @param body - function body closure
- * @param deps - array of userland functions called from this function
  */
-// prettier-ignore
-export function defn<T extends Type>(type: T, name: Nullable<string>, args: [], body: FnBody0): TaggedFn0<T>;
-// prettier-ignore
-export function defn<T extends Type, A extends Type>(type: T, name: Nullable<string>, args: Arg1<A>, body: FnBody1<A>): TaggedFn1<A,T>;
-// prettier-ignore
-export function defn<T extends Type, A extends Type, B extends Type>(type: T, name: Nullable<string>, args: Arg2<A,B>, body: FnBody2<A,B>): TaggedFn2<A,B,T>;
-// prettier-ignore
-export function defn<T extends Type, A extends Type, B extends Type, C extends Type>(type: T, name: Nullable<string>, args: Arg3<A,B,C>, body: FnBody3<A,B,C>): TaggedFn3<A,B,C,T>;
-// prettier-ignore
-export function defn<T extends Type, A extends Type, B extends Type, C extends Type, D extends Type>(type: T, name: Nullable<string>, args: Arg4<A,B,C,D>, body: FnBody4<A,B,C,D>): TaggedFn4<A,B,C,D,T>;
-// prettier-ignore
-export function defn<T extends Type, A extends Type, B extends Type, C extends Type, D extends Type, E extends Type>(type: T, name: Nullable<string>, args: Arg5<A,B,C,D,E>, body: FnBody5<A,B,C,D,E>): TaggedFn5<A,B,C,D,E,T>;
-// prettier-ignore
-export function defn<T extends Type, A extends Type, B extends Type, C extends Type, D extends Type, E extends Type, F extends Type>(type: T, name: Nullable<string>, args: Arg6<A,B,C,D,E,F>, body: FnBody6<A,B,C,D,E,F>): TaggedFn6<A,B,C,D,E,F,T>;
-// prettier-ignore
-export function defn<T extends Type, A extends Type, B extends Type, C extends Type, D extends Type, E extends Type, F extends Type, G extends Type>(type: T, name: Nullable<string>, args: Arg7<A,B,C,D,E,F,G>, body: FnBody7<A,B,C,D,E,F,G>): TaggedFn7<A,B,C,D,E,F,G,T>;
-// prettier-ignore
-export function defn<T extends Type, A extends Type, B extends Type, C extends Type, D extends Type, E extends Type, F extends Type, G extends Type, H extends Type>(type: T, name: Nullable<string>, args: Arg8<A,B,C,D,E,F,G,H>, body: FnBody8<A,B,C,D,E,F,G,H>): TaggedFn8<A,B,C,D,E,F,G,H,T>;
-// prettier-ignore
+export function defn<
+	T extends Type,
+    Args extends VariadicArgs<Type[]>,
+    Xs extends VariadicTypeOfArg<Args>,
+>(
+	type: T,
+	name: Nullable<string>,
+	args: [...Args],
+	body: VariadicFnBody<Xs>
+): VariadicTaggedFn<Xs, T>;
 export function defn(type: Type, id: Nullable<string>, _args: Arg<any>[], _body: (...xs: Sym<any>[]) => ScopeBody): Func<any> {
     id = id || gensym();
     const args = _args.map(defArg);
@@ -142,7 +112,6 @@ export function defn(type: Type, id: Nullable<string>, _args: Arg<any>[], _body:
  * @param body -
  */
 export const defMain = (body: FnBody0) => defn("void", "main", [], body);
-
 export function ret(): FuncReturn<"void">;
 export function ret<T extends Type>(val: Term<T>): FuncReturn<T>;
 export function ret(val?: Term<any>): FuncReturn<any> {
@@ -153,26 +122,11 @@ export function ret(val?: Term<any>): FuncReturn<any> {
 	};
 }
 
-// prettier-ignore
 export function funcall<T extends Type>(fn: string, type: T, ...args: Term<any>[]): FnCall<T>;
-export function funcall<T extends Type>(fn: TaggedFn0<T>): FnCall<T>;
-// prettier-ignore
-export function funcall<A extends Type, T extends Type>(fn: TaggedFn1<A,T>, a: Term<A>): FnCall<T>;
-// prettier-ignore
-export function funcall<A extends Type, B extends Type, T extends Type>(fn: TaggedFn2<A,B,T>, a: Term<A>, b: Term<B>): FnCall<T>;
-// prettier-ignore
-export function funcall<A extends Type, B extends Type, C extends Type, T extends Type>(fn: TaggedFn3<A,B,C,T>, a: Term<A>, b: Term<B>, c: Term<C>): FnCall<T>;
-// prettier-ignore
-export function funcall<A extends Type, B extends Type, C extends Type, D extends Type, T extends Type>(fn: TaggedFn4<A,B,C,D,T>, a: Term<A>, b: Term<B>, c: Term<C>, d: Term<D>): FnCall<T>;
-// prettier-ignore
-export function funcall<A extends Type, B extends Type, C extends Type, D extends Type, E extends Type, T extends Type>(fn: TaggedFn5<A,B,C,D,E,T>, a: Term<A>, b: Term<B>, c: Term<C>, d: Term<D>, e: Term<E>): FnCall<T>;
-// prettier-ignore
-export function funcall<A extends Type, B extends Type, C extends Type, D extends Type, E extends Type, F extends Type, T extends Type>(fn: TaggedFn6<A,B,C,D,E,F,T>, a: Term<A>, b: Term<B>, c: Term<C>, d: Term<D>, e: Term<E>, f: Term<F>): FnCall<T>;
-// prettier-ignore
-export function funcall<A extends Type, B extends Type, C extends Type, D extends Type, E extends Type, F extends Type, G extends Type, T extends Type>(fn: TaggedFn7<A,B,C,D,E,F,G,T>, a: Term<A>, b: Term<B>, c: Term<C>, d: Term<D>, e: Term<E>, f: Term<F>, g: Term<G>): FnCall<T>;
-// prettier-ignore
-export function funcall<A extends Type, B extends Type, C extends Type, D extends Type, E extends Type, F extends Type, G extends Type, H extends Type, T extends Type>(fn: TaggedFn8<A,B,C,D,E,F,G,H,T>, a: Term<A>, b: Term<B>, c: Term<C>, d: Term<D>, e: Term<E>, f: Term<F>, g: Term<G>, h: Term<H>): FnCall<T>;
-// prettier-ignore
+export function funcall<Xs extends Type[], T extends Type>(
+	fn: VariadicTaggedFn<Xs, T>,
+	...args: VariadicTerms<Xs>
+): FnCall<T>;
 export function funcall(fn: string | Func<any>, ...args: Term<any>[]): FnCall<any> {
     return isString(fn)
         ? {

--- a/packages/shader-ast/src/ast/ops.ts
+++ b/packages/shader-ast/src/ast/ops.ts
@@ -121,9 +121,9 @@ export function add<A extends Prim | Int | IVec | Mat, B extends A>(l: Term<A>, 
 export function add<T extends Int | "float">(l: number, r: Term<T>): Op2<T>;
 export function add<T extends Int | "float">(l: Term<T>, r: number): Op2<T>;
 // prettier-ignore
-export function add<T extends Vec | Mat>(l: FloatTerm | number, r: Term<T>): Op2<T>;
+export function add<T extends 'float' | Vec | Mat>(l: FloatTerm | number, r: Term<T>): Op2<T>;
 // prettier-ignore
-export function add<T extends Vec | Mat>(l: Term<T>, r: FloatTerm | number): Op2<T>;
+export function add<T extends 'float' | Vec | Mat>(l: Term<T>, r: FloatTerm | number): Op2<T>;
 // prettier-ignore
 export function add<T extends IVec>(l: IntTerm | number, r: Term<T>): Op2<T>;
 // prettier-ignore
@@ -142,9 +142,9 @@ export function sub<A extends Prim | Int | IVec | Mat, B extends A>(l: Term<A>, 
 export function sub<T extends Int | "float">(l: number, r: Term<T>): Op2<T>;
 export function sub<T extends Int | "float">(l: Term<T>, r: number): Op2<T>;
 // prettier-ignore
-export function sub<T extends Vec | Mat>(l: FloatTerm | number, r: Term<T>): Op2<T>;
+export function sub<T extends 'float' | Vec | Mat>(l: FloatTerm | number, r: Term<T>): Op2<T>;
 // prettier-ignore
-export function sub<T extends Vec | Mat>(l: Term<T>, r: FloatTerm | number): Op2<T>;
+export function sub<T extends 'float' | Vec | Mat>(l: Term<T>, r: FloatTerm | number): Op2<T>;
 // prettier-ignore
 export function sub<T extends IVec>(l: IntTerm | number, r: Term<T>): Op2<T>;
 // prettier-ignore
@@ -162,9 +162,9 @@ export function mul<A extends Prim | Int | IVec | Mat, B extends A>(l: Term<A>, 
 export function mul<T extends Int | "float">(l: number, r: Term<T>): Op2<T>;
 export function mul<T extends Int | "float">(l: Term<T>, r: number): Op2<T>;
 // prettier-ignore
-export function mul<T extends Vec | Mat>(l: FloatTerm | number, r: Term<T>): Op2<T>;
+export function mul<T extends 'float' | Vec | Mat>(l: FloatTerm | number, r: Term<T>): Op2<T>;
 // prettier-ignore
-export function mul<T extends Vec | Mat>(l: Term<T>, r: FloatTerm | number): Op2<T>;
+export function mul<T extends 'float' | Vec | Mat>(l: Term<T>, r: FloatTerm | number): Op2<T>;
 // prettier-ignore
 export function mul<T extends IVec>(l: IntTerm | number, r: Term<T>): Op2<T>;
 // prettier-ignore
@@ -195,9 +195,9 @@ export function div<A extends Prim | Int | IVec | Mat, B extends A>(l: Term<A>, 
 export function div<T extends Int | "float">(l: number, r: Term<T>): Op2<T>;
 export function div<T extends Int | "float">(l: Term<T>, r: number): Op2<T>;
 // prettier-ignore
-export function div<T extends Vec | Mat>(l: FloatTerm | number, r: Term<T>): Op2<T>;
+export function div<T extends 'float' | Vec | Mat>(l: FloatTerm | number, r: Term<T>): Op2<T>;
 // prettier-ignore
-export function div<T extends Vec | Mat>(l: Term<T>, r: FloatTerm | number): Op2<T>;
+export function div<T extends 'float' | Vec | Mat>(l: Term<T>, r: FloatTerm | number): Op2<T>;
 // prettier-ignore
 export function div<T extends IVec>(l: IntTerm | number, r: Term<T>): Op2<T>;
 // prettier-ignore

--- a/packages/shader-ast/test/main.test.ts
+++ b/packages/shader-ast/test/main.test.ts
@@ -13,6 +13,7 @@ import {
 	vec2,
 	vec3,
 	type Lit,
+	type Sym,
 } from "../src/index.js";
 
 test("op2 type infer mulvv", () => {
@@ -244,4 +245,36 @@ test("texture", () => {
 		tag: "call_i",
 		type: "vec4",
 	});
+});
+
+test("type infer of defn", () => {
+	const f = defn(
+		"void",
+		undefined,
+		[],
+		() => []
+	);
+	const g = defn(
+		"void",
+		undefined,
+		["float", "int"],
+		(x, y) => {
+			const a: Sym<"float"> = x;
+			const b: Sym<"int"> = y;
+			return [a, b];
+		}
+	);
+	const h = defn(
+		"void",
+		undefined,
+		["int", ["float", "x"]],
+		(x, y) => {
+			const a: Sym<"int"> = x;
+			const b: Sym<"float"> = y;
+			return [a, b];
+		}
+	);
+	f();
+	g(sym("float"), sym("int"));
+	h(sym("int"), sym("float"));
 });


### PR DESCRIPTION
It is possible to avoid overloads `TaggedFn5, TaggedFn6, ...` by using variadic tuple types and mapped types.
I try to demonstrate the implementation here.

Also, I think that `args: [...Args],` is very nontrivial here, such that if I just do `args: Args`, and if I pass array like `['int', 'float', 'bool']`, the types of parameters are inferred as `Sym<'int' | 'float' | 'bool'>` which is not desirable.

As I check the integration with `stdlib`, 
I had seen some failing cases of implementation that uses very generic types, 
such as matching types of `mul<TypeOfArg<T>, 'float'>`.
However, I was able to fix the issues by extending some overloads in arithmetic operators.,
and this could be better because I could also get rid of `any` casting that had used to work around already broken type inference.

The other rationale that I want to remove the restriction of number of parateters of function, 
is that `shader-ast` does not support struct yet.
The only workaround to transform a program that uses struct, into a program that doesn't use struct, is
to expand struct into a lot of variables,
and to use functions with many parameters with `out` or `inout` qualifier.
And I worry about if I encouter such limitations in production, and if I want to avoid 'death by a thousand overloads' problem.
So it can be useful to remove such limitation to define functions more than 8 parameters.
