### PR TITLE
fix(cache): attempt to add element bigger than `maxsize` blocks addition of any new elements to the cache

### DIFF
--- a/packages/cache/src/lru.ts
+++ b/packages/cache/src/lru.ts
@@ -101,8 +101,13 @@ export class LRUCache<K, V> implements ICache<K, V> {
 	set(key: K, value: V) {
 		const size = this.opts.ksize(key) + this.opts.vsize(value);
 		const e = this.map.get(key);
-		this._size += Math.max(0, size - (e ? e.value.s : 0));
-		this.ensureSize() && this.doSetEntry(e, key, value, size);
+		const additionalSize = Math.max(0, size - (e ? e.value.s : 0));
+		this._size += additionalSize;
+		if (this.ensureSize()) {
+			this.doSetEntry(e, key, value, size);
+		} else {
+			this._size -= additionalSize;
+		}
 		return value;
 	}
 

--- a/packages/cache/src/tlru.ts
+++ b/packages/cache/src/tlru.ts
@@ -60,7 +60,8 @@ export class TLRUCache<K, V> extends LRUCache<K, V> {
 	set(key: K, value: V, ttl = this.opts.ttl) {
 		const size = this.opts.ksize(key) + this.opts.vsize(value);
 		const e = this.map.get(key);
-		this._size += Math.max(0, size - (e ? e.value.s : 0));
+		const additionalSize = Math.max(0, size - (e ? e.value.s : 0));
+		this._size += additionalSize;
 		if (this.ensureSize()) {
 			const t = Date.now() + ttl;
 			if (e) {
@@ -77,6 +78,8 @@ export class TLRUCache<K, V> extends LRUCache<K, V> {
 				});
 				this.map.set(key, this.items.tail!);
 			}
+		} else {
+			this._size -= additionalSize;
 		}
 		return value;
 	}

--- a/packages/cache/src/tlru.ts
+++ b/packages/cache/src/tlru.ts
@@ -64,20 +64,7 @@ export class TLRUCache<K, V> extends LRUCache<K, V> {
 		this._size += additionalSize;
 		if (this.ensureSize()) {
 			const t = Date.now() + ttl;
-			if (e) {
-				e.value.v = value;
-				e.value.s = size;
-				e.value.t = t;
-				this.items.asTail(e);
-			} else {
-				this.items.push({
-					k: key,
-					v: value,
-					s: size,
-					t,
-				});
-				this.map.set(key, this.items.tail!);
-			}
+			this.doSetTlruEntry(e, key, value, size, t);
 		} else {
 			this._size -= additionalSize;
 		}
@@ -115,5 +102,23 @@ export class TLRUCache<K, V> extends LRUCache<K, V> {
 			cell = cell.next;
 		}
 		return super.ensureSize();
+	}
+
+	protected doSetTlruEntry(
+		e: ConsCell<TLRUCacheEntry<K, V>> | undefined,
+		k: K,
+		v: V,
+		s: number,
+		t: number
+	) {
+		if (e) {
+			e.value.v = v;
+			e.value.s = s;
+			e.value.t = t;
+			this.items.asTail(e);
+		} else {
+			this.items.push({ k, v, s, t });
+			this.map.set(k, this.items.tail!);
+		}
 	}
 }


### PR DESCRIPTION
On attempt to add an element bigger than `maxsize`, regardless of the fact that the element isn't actually added to the cache, size of that element is added to `this._size`, blocking addition of any new elements to the cache