### PR TITLE
fix(geom-api): __samples attribute should be Partial<SamplingOpts>

### DIFF
--- a/packages/geom-api/src/shape.ts
+++ b/packages/geom-api/src/shape.ts
@@ -6,7 +6,7 @@ export interface Attribs {
 	/**
 	 * Shape resampling options/resolution.
 	 */
-	__samples?: SamplingOpts | number;
+	__samples?: Partial<SamplingOpts> | number;
 	/**
 	 * Control attribute to define the number of fractional digits for numeric
 	 * values in the serialized SVG string.


### PR DESCRIPTION
Fixes a build failure in `geom-axidraw`, and looking at the usages of `__samples` it seems like it's intended to be `Partial`.