### PR TITLE
FIX/packages/sax: make sure CDATA content is parsed into 'body'

### DIFF
--- a/packages/sax/src/index.ts
+++ b/packages/sax/src/index.ts
@@ -508,6 +508,7 @@ const PARSER: FSMStateMap<ParseState, string, ParseEvent[]> = {
 					return;
 				}
 			}
+			state.scope[state.scope.length - 1].body = b;
 			return [{ type: Type.CDATA, body: b }];
 		} else {
 			state.body += ch;


### PR DESCRIPTION
Hey hey, 

Today I tried to use [thi.ng/sax](https://thi.ng/sax) to parse an RSS XML feed, which eventually has CDATA inside some markup tags, e.g.

```xml
<description>
<![CDATA[ News, stories, features and analysis ]]>
</description>
```

Unfortunatelly the CDATA content was missing, I assume it should be parsed as `body` for the given element. Here's a quick example:

```typescript
import * as sax from "@thi.ng/sax";
import * as tx from "@thi.ng/transducers";

const input = [`<a><d>Content</d></a>`,
			   `<a><d><![CDATA[Content]]></d></a>`];

function process(input: string) {
	console.group(`Input: ${input}`);
	const doc = tx.transduce(
		sax.parse({ entities: true, children: true }),
		tx.last(),
		input,
	);

	console.log(doc!.children![0]);
	console.groupEnd();
}

tx.transduce(tx.map(process), tx.last(), input);
```

which leads to the following output:
<img width="548" alt="Screenshot 2024-07-09 at 22 54 11" src="https://github.com/thi-ng/umbrella/assets/463136/5bb8b8d7-d85b-4a5c-8dc9-ac8cb534d0c2">

```javascript
Input: <a><d>Content</d></a>
{tag: 'd', attribs: {…}, children: Array(0), body: 'Content'}

Input: <a><d><![CDATA[Content]]></d></a>
{tag: 'd', attribs: {…}, children: Array(0)} // missing "body: 'Content'" here
```

spun up the debugger, it looks like there was a line missing [here](https://github.com/guidoschmidt/umbrella/commit/fe2094ae77bfad213ef035d85cb91c520f9cea1f) in order to get the CDATA parsed as `body`.