### PR TITLE
docs: use same parameter names as in doc string

### DIFF
--- a/packages/vectors/src/cartesian.ts
+++ b/packages/vectors/src/cartesian.ts
@@ -27,8 +27,8 @@ export const cartesian: MultiVecOpVO<ReadonlyVec> = vop(1);
  * @param v -
  * @param offset -
  */
-export const cartesian2 = cartesian.add(2, (out, a, b = ZERO2) =>
-	add2(out || a, cossin(a[1], a[0]), b)
+export const cartesian2 = cartesian.add(2, (out, v, offset = ZERO2) =>
+	add2(out || v, cossin(v[1], v[0]), offset)
 );
 
 /**
@@ -40,15 +40,15 @@ export const cartesian2 = cartesian.add(2, (out, a, b = ZERO2) =>
  * @param v -
  * @param offset -
  */
-export const cartesian3 = cartesian.add(3, (out, a, b = ZERO3) => {
-	const r = a[0];
-	const theta = a[1];
-	const phi = a[2];
+export const cartesian3 = cartesian.add(3, (out, v, offset = ZERO3) => {
+	const r = v[0];
+	const theta = v[1];
+	const phi = v[2];
 	const ct = cos(theta);
 	return setC3(
-		out || a,
-		r * ct * cos(phi) + b[0],
-		r * ct * sin(phi) + b[1],
-		r * sin(theta) + b[2]
+		out || v,
+		r * ct * cos(phi) + offset[0],
+		r * ct * sin(phi) + offset[1],
+		r * sin(theta) + offset[2]
 	);
 });

--- a/packages/vectors/src/polar.ts
+++ b/packages/vectors/src/polar.ts
@@ -24,8 +24,8 @@ export const polar: MultiVecOpV = vop(1);
  * @param out -
  * @param v -
  */
-export const polar2 = polar.add(2, (out, a) =>
-	setC2(out || a, mag(a), atan2(a[1], a[0]))
+export const polar2 = polar.add(2, (out, v) =>
+	setC2(out || v, mag(v), atan2(v[1], v[0]))
 );
 
 /**
@@ -36,12 +36,12 @@ export const polar2 = polar.add(2, (out, a) =>
  * @param out -
  * @param v -
  */
-export const polar3 = polar.add(3, (out, a) => {
-	const x = a[0];
-	const y = a[1];
-	const z = a[2];
+export const polar3 = polar.add(3, (out, v) => {
+	const x = v[0];
+	const y = v[1];
+	const z = v[2];
 	const r = sqrt(x * x + y * y + z * z);
 	return r > 0
-		? setC3(out || a, r, asin(z / r), atan2(y, x))
-		: setC3(out || a, 0, 0, 0);
+		? setC3(out || v, r, asin(z / r), atan2(y, x))
+		: setC3(out || v, 0, 0, 0);
 });


### PR DESCRIPTION
I realized that there is a naming mismatch in the text mismatch when looking at the docs for the polar / cartesian conversion fns: https://docs.thi.ng/umbrella/vectors/functions/cartesian.html.

I changed the references in the source code, but still saw the docs using `cartesian(out, a, b?)` as the function signature after generating the docs locally. I ran the following commands to regenerate the docs:

```
yarn clean
yarn build
yarn doc:ae
yarn doc
```

Is there anything else to do? I didn't find anything with `rg -i 'cartesian.*?out.*?a.*?b'`. 

If this is a bug in typedoc I may also go the other way around and rename the function params to `a` and `b`.