### PR TITLE
docs: enable sourcemaps in examples

### DIFF
--- a/examples/adaptive-threshold/vite.config.js
+++ b/examples/adaptive-threshold/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/ascii-raymarch/vite.config.js
+++ b/examples/ascii-raymarch/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/async-effect/vite.config.js
+++ b/examples/async-effect/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/big-font/vite.config.js
+++ b/examples/big-font/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/bitmap-font/vite.config.js
+++ b/examples/bitmap-font/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/blurhash/vite.config.js
+++ b/examples/blurhash/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/boid-basics/vite.config.js
+++ b/examples/boid-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/canvas-dial/vite.config.js
+++ b/examples/canvas-dial/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/canvas-recorder/vite.config.js
+++ b/examples/canvas-recorder/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/cellular-automata/vite.config.js
+++ b/examples/cellular-automata/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/color-themes/vite.config.js
+++ b/examples/color-themes/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/commit-heatmap/vite.config.js
+++ b/examples/commit-heatmap/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/commit-table-ssr/vite.config.js
+++ b/examples/commit-table-ssr/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/crypto-chart/vite.config.js
+++ b/examples/crypto-chart/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/csp-bus/vite.config.js
+++ b/examples/csp-bus/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/devcards/vite.config.js
+++ b/examples/devcards/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/dominant-colors/vite.config.js
+++ b/examples/dominant-colors/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/ellipse-proximity/vite.config.js
+++ b/examples/ellipse-proximity/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/fft-synth/vite.config.js
+++ b/examples/fft-synth/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/fiber-basics/vite.config.js
+++ b/examples/fiber-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-classify-point/vite.config.js
+++ b/examples/geom-classify-point/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-complex-poly/vite.config.js
+++ b/examples/geom-complex-poly/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-convex-hull/vite.config.js
+++ b/examples/geom-convex-hull/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-csv-piechart/vite.config.js
+++ b/examples/geom-csv-piechart/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-extra-hiccup/vite.config.js
+++ b/examples/geom-extra-hiccup/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-fuzz-basics/vite.config.js
+++ b/examples/geom-fuzz-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-hexgrid/vite.config.js
+++ b/examples/geom-hexgrid/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-knn-hash/vite.config.js
+++ b/examples/geom-knn-hash/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-knn/vite.config.js
+++ b/examples/geom-knn/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-sdf-logo/vite.config.js
+++ b/examples/geom-sdf-logo/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-sdf-path/vite.config.js
+++ b/examples/geom-sdf-path/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-terrain-viz/vite.config.js
+++ b/examples/geom-terrain-viz/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-tessel/vite.config.js
+++ b/examples/geom-tessel/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-unique-edges/vite.config.js
+++ b/examples/geom-unique-edges/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-voronoi-mst/vite.config.js
+++ b/examples/geom-voronoi-mst/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-webgl-attrib-pool/vite.config.js
+++ b/examples/geom-webgl-attrib-pool/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/geom-webgl-basics/vite.config.js
+++ b/examples/geom-webgl-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/gesture-analysis/vite.config.js
+++ b/examples/gesture-analysis/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/gpgpu-reduce/vite.config.js
+++ b/examples/gpgpu-reduce/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/grid-iterators/vite.config.js
+++ b/examples/grid-iterators/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-basics/vite.config.js
+++ b/examples/hdom-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-benchmark/vite.config.js
+++ b/examples/hdom-benchmark/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-benchmark2/vite.config.js
+++ b/examples/hdom-benchmark2/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-canvas-clock/vite.config.js
+++ b/examples/hdom-canvas-clock/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-canvas-draw/vite.config.js
+++ b/examples/hdom-canvas-draw/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-canvas-particles/vite.config.js
+++ b/examples/hdom-canvas-particles/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-canvas-shapes/vite.config.js
+++ b/examples/hdom-canvas-shapes/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-dropdown-fuzzy/vite.config.js
+++ b/examples/hdom-dropdown-fuzzy/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-dropdown/vite.config.js
+++ b/examples/hdom-dropdown/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-dyn-context/vite.config.js
+++ b/examples/hdom-dyn-context/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-elm/vite.config.js
+++ b/examples/hdom-elm/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-inner-html/vite.config.js
+++ b/examples/hdom-inner-html/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-local-render/vite.config.js
+++ b/examples/hdom-local-render/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-localstate/vite.config.js
+++ b/examples/hdom-localstate/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-skip-nested/vite.config.js
+++ b/examples/hdom-skip-nested/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-skip/vite.config.js
+++ b/examples/hdom-skip/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-theme-adr-0003/vite.config.js
+++ b/examples/hdom-theme-adr-0003/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-toggle/vite.config.js
+++ b/examples/hdom-toggle/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hdom-vscroller/vite.config.js
+++ b/examples/hdom-vscroller/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hiccup-canvas-arcs/vite.config.js
+++ b/examples/hiccup-canvas-arcs/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hiccup-canvas-basics/vite.config.js
+++ b/examples/hiccup-canvas-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hiccup-css-image-transition/vite.config.js
+++ b/examples/hiccup-css-image-transition/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/hydrate-basics/vite.config.js
+++ b/examples/hydrate-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/ifs-fractal/vite.config.js
+++ b/examples/ifs-fractal/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/imgui-basics/vite.config.js
+++ b/examples/imgui-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/imgui/vite.config.js
+++ b/examples/imgui/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/interceptor-basics/vite.config.js
+++ b/examples/interceptor-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/interceptor-basics2/vite.config.js
+++ b/examples/interceptor-basics2/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/iso-plasma/vite.config.js
+++ b/examples/iso-plasma/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/json-components/vite.config.js
+++ b/examples/json-components/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/kmeans-viz/vite.config.js
+++ b/examples/kmeans-viz/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/layout-gridgen/vite.config.js
+++ b/examples/layout-gridgen/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/lispy-repl/vite.config.js
+++ b/examples/lispy-repl/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/login-form/vite.config.js
+++ b/examples/login-form/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/mandelbrot/vite.config.js
+++ b/examples/mandelbrot/vite.config.js
@@ -1,4 +1,7 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 	worker: { format: "es" },
 };

--- a/examples/markdown/vite.config.js
+++ b/examples/markdown/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/mastodon-feed/vite.config.js
+++ b/examples/mastodon-feed/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/meta-css-basics/vite.config.js
+++ b/examples/meta-css-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/multitouch/vite.config.js
+++ b/examples/multitouch/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/package-stats/vite.config.js
+++ b/examples/package-stats/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/parse-playground/vite.config.js
+++ b/examples/parse-playground/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pixel-basics/vite.config.js
+++ b/examples/pixel-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pixel-colormatrix/vite.config.js
+++ b/examples/pixel-colormatrix/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pixel-dither/vite.config.js
+++ b/examples/pixel-dither/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pixel-gradients/vite.config.js
+++ b/examples/pixel-gradients/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pixel-indexed/vite.config.js
+++ b/examples/pixel-indexed/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pixel-normal-map/vite.config.js
+++ b/examples/pixel-normal-map/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pixel-sorting/vite.config.js
+++ b/examples/pixel-sorting/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pixel-waveform/vite.config.js
+++ b/examples/pixel-waveform/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pointfree-geom/vite.config.js
+++ b/examples/pointfree-geom/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/pointfree-svg/vite.config.js
+++ b/examples/pointfree-svg/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/poisson-circles/vite.config.js
+++ b/examples/poisson-circles/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/poly-spline/vite.config.js
+++ b/examples/poly-spline/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/poly-subdiv/vite.config.js
+++ b/examples/poly-subdiv/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/porter-duff/vite.config.js
+++ b/examples/porter-duff/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/procedural-text/vite.config.js
+++ b/examples/procedural-text/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/quasi-lattice/vite.config.js
+++ b/examples/quasi-lattice/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/ramp-scroll-anim/vite.config.js
+++ b/examples/ramp-scroll-anim/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/ramp-synth/vite.config.js
+++ b/examples/ramp-synth/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rasterize-blend/vite.config.js
+++ b/examples/rasterize-blend/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-async/vite.config.js
+++ b/examples/rdom-async/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-basics/vite.config.js
+++ b/examples/rdom-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-canvas-basics/vite.config.js
+++ b/examples/rdom-canvas-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-delayed-update/vite.config.js
+++ b/examples/rdom-delayed-update/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-dnd/vite.config.js
+++ b/examples/rdom-dnd/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-formgen/vite.config.js
+++ b/examples/rdom-formgen/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-key-sequences/vite.config.js
+++ b/examples/rdom-key-sequences/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-klist/vite.config.js
+++ b/examples/rdom-klist/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-lazy-load/vite.config.js
+++ b/examples/rdom-lazy-load/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-lissajous/vite.config.js
+++ b/examples/rdom-lissajous/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-reactive-svg/vite.config.js
+++ b/examples/rdom-reactive-svg/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-router/vite.config.js
+++ b/examples/rdom-router/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-search-docs/vite.config.js
+++ b/examples/rdom-search-docs/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-svg-nodes/vite.config.js
+++ b/examples/rdom-svg-nodes/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rdom-web-components/vite.config.js
+++ b/examples/rdom-web-components/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/related-images/vite.config.js
+++ b/examples/related-images/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/render-audio/vite.config.js
+++ b/examples/render-audio/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rotating-voronoi/vite.config.js
+++ b/examples/rotating-voronoi/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/router-basics/vite.config.js
+++ b/examples/router-basics/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rstream-dataflow/vite.config.js
+++ b/examples/rstream-dataflow/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rstream-event-loop/vite.config.js
+++ b/examples/rstream-event-loop/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rstream-grid/vite.config.js
+++ b/examples/rstream-grid/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rstream-hdom/vite.config.js
+++ b/examples/rstream-hdom/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rstream-spreadsheet/vite.config.js
+++ b/examples/rstream-spreadsheet/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rstream-sync/vite.config.js
+++ b/examples/rstream-sync/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/rstream-system-bus/vite.config.js
+++ b/examples/rstream-system-bus/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/scenegraph-image/vite.config.js
+++ b/examples/scenegraph-image/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/scenegraph/vite.config.js
+++ b/examples/scenegraph/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/shader-ast-canvas2d/vite.config.js
+++ b/examples/shader-ast-canvas2d/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/shader-ast-easings/vite.config.js
+++ b/examples/shader-ast-easings/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/shader-ast-evo/vite.config.js
+++ b/examples/shader-ast-evo/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/shader-ast-noise/vite.config.js
+++ b/examples/shader-ast-noise/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/shader-ast-raymarch/vite.config.js
+++ b/examples/shader-ast-raymarch/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/shader-ast-sdf2d/vite.config.js
+++ b/examples/shader-ast-sdf2d/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/shader-ast-tunnel/vite.config.js
+++ b/examples/shader-ast-tunnel/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/shader-ast-workers/vite.config.js
+++ b/examples/shader-ast-workers/vite.config.js
@@ -1,4 +1,7 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 	worker: { format: "es" },
 };

--- a/examples/shader-graph/vite.config.js
+++ b/examples/shader-graph/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/simd-plot/vite.config.js
+++ b/examples/simd-plot/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/soa-ecs/vite.config.js
+++ b/examples/soa-ecs/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/spline-tangent/vite.config.js
+++ b/examples/spline-tangent/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/stacked-layout/vite.config.js
+++ b/examples/stacked-layout/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/stratified-grid/vite.config.js
+++ b/examples/stratified-grid/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/svg-barchart/vite.config.js
+++ b/examples/svg-barchart/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/svg-particles/vite.config.js
+++ b/examples/svg-particles/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/svg-resample/vite.config.js
+++ b/examples/svg-resample/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/svg-waveform/vite.config.js
+++ b/examples/svg-waveform/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/talk-slides/vite.config.js
+++ b/examples/talk-slides/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/text-canvas-image/vite.config.js
+++ b/examples/text-canvas-image/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/text-canvas/vite.config.js
+++ b/examples/text-canvas/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/thing-packages-quiz/vite.config.js
+++ b/examples/thing-packages-quiz/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/todo-list/vite.config.js
+++ b/examples/todo-list/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/trace-bitmap/vite.config.js
+++ b/examples/trace-bitmap/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/transducers-hdom/vite.config.js
+++ b/examples/transducers-hdom/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/triple-query/vite.config.js
+++ b/examples/triple-query/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/unbiased-normals/vite.config.js
+++ b/examples/unbiased-normals/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/viz-ridge-lines/vite.config.js
+++ b/examples/viz-ridge-lines/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/viz-scatter-plot/vite.config.js
+++ b/examples/viz-scatter-plot/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-channel-mixer/vite.config.js
+++ b/examples/webgl-channel-mixer/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-cube/vite.config.js
+++ b/examples/webgl-cube/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-cubemap/vite.config.js
+++ b/examples/webgl-cubemap/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-float-fbo/vite.config.js
+++ b/examples/webgl-float-fbo/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-game-of-life/vite.config.js
+++ b/examples/webgl-game-of-life/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-grid/vite.config.js
+++ b/examples/webgl-grid/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-msdf/vite.config.js
+++ b/examples/webgl-msdf/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-multipass/vite.config.js
+++ b/examples/webgl-multipass/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-shadertoy/vite.config.js
+++ b/examples/webgl-shadertoy/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-ssao/vite.config.js
+++ b/examples/webgl-ssao/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/webgl-texture-paint/vite.config.js
+++ b/examples/webgl-texture-paint/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/wolfram/vite.config.js
+++ b/examples/wolfram/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/xml-converter/vite.config.js
+++ b/examples/xml-converter/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/zig-canvas/vite.config.js
+++ b/examples/zig-canvas/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/zig-cellular/vite.config.js
+++ b/examples/zig-cellular/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/zig-counter/vite.config.js
+++ b/examples/zig-counter/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };

--- a/examples/zig-todo-list/vite.config.js
+++ b/examples/zig-todo-list/vite.config.js
@@ -1,3 +1,6 @@
 export default {
-	build: { target: "esnext" },
+	build: {
+		target: "esnext",
+		sourcemap: true,
+	},
 };


### PR DESCRIPTION
This enables source maps in all example builds, as discussed in https://github.com/thi-ng/umbrella/discussions/483.

I think the patch was applied correctly, but I wasn't able to test all examples. From what I can tell there are two different configs:

```js
// taken from examples/mandelbrot, but is also in examples/shader-ast-workers and others
export default {
	build: { target: "esnext" },
	worker: { format: "es" },
};
```

and the simpler one without a worker config:

```js
// used almost everywhere
export default {
	build: { target: "esnext" },
};
```

I have bult the `pointfree-geom` and `mandelbrot` examples and tested them via `yarn build && yarn preview` and both work fine!